### PR TITLE
Show host details on a stack

### DIFF
--- a/stackdio/core/static/stackdio/store/StackHosts.js
+++ b/stackdio/core/static/stackdio/store/StackHosts.js
@@ -1,0 +1,10 @@
+define(['store/store', 'api/StackHosts'], function (store, API) {
+    var StackHosts = function () {
+        this.proxy = API;
+    }
+
+    StackHosts.prototype = new store();
+    StackHosts.prototype.constructor = StackHosts;
+
+    return new StackHosts();
+});

--- a/stackdio/core/static/stackdio/store/store.js
+++ b/stackdio/core/static/stackdio/store/store.js
@@ -46,7 +46,15 @@ define(['q', 'knockout'], function (Q, ko) {
     };
 
     Store.prototype.add = function (type) {
-        this.collection.push(type);
+        var self = this;
+
+        if (type instanceof Array) {
+            type.forEach(function (item) {
+                self.collection.push(item);
+            });
+        } else {
+            self.collection.push(type);
+        }
     };
 
     Store.prototype.empty = function () {

--- a/stackdio/core/static/stackdio/view/stack.html
+++ b/stackdio/core/static/stackdio/view/stack.html
@@ -7,12 +7,12 @@
 
         <ul class="nav nav-tabs">
             <li class="active"><a href="#detail" class="small-heading" data-toggle="tab">Stack Details</a></li>
+            <li><a href="#hosts" class="small-heading" data-toggle="tab" data-bind="visible: editMode() === 'update'">Stack Hosts</a></li>
             <li><a href="#logs" class="small-heading" data-toggle="tab" data-bind="visible: editMode() === 'update'">Stack Logs</a></li>
         </ul>
 
         <div class="tab-content">
             <div class="tab-pane active" id="detail">
-
                 <form id="stack-launch-form" role="form">
                     <div class="form-group">
                         <label for="blueprint_title" class=" control-label">Blueprint</label>
@@ -37,15 +37,15 @@
                     <div class="form-group">
                         <label class="control-label" for="stack_properties_preview">Stack Properties</label>
                         <textarea  
-                               class="form-control" 
-                               rows="20"
-                               id="stack_properties_preview" 
-                               data-bind="text: $root.stackPropertiesStringified()"
-                               placeholder="The formulas for the selected Blueprint do not contain properties"></textarea>
+                            class="form-control" 
+                            rows="20"
+                            id="stack_properties_preview" 
+                            data-bind="text: $root.stackPropertiesStringified()"
+                            placeholder="The formulas for the selected Blueprint do not contain properties"></textarea>
                     </div>
 
                     <div class="row">
-                         <div class="col-md-3 col-md-offset-9  pull-right">
+                        <div class="col-md-3 col-md-offset-9  pull-right">
                             <button class="btn" data-bind="click: cancelChanges">Cancel</button>
                             <button class="btn btn-primary" data-bind="visible: editMode() === 'create', click: $root.provisionStack">Begin Provisioning</button>
                             <button class="btn btn-primary" data-bind="visible: editMode() === 'update', click: $root.updateStack">Save</button>
@@ -53,8 +53,29 @@
                     </div>
                 </form>
                 <div class="row">
-                  <hr/>
+                    <hr/>
                 </div>
+            </div>
+
+            <div class="tab-pane active" id="hosts">
+                <table id="stack-hosts" class="table table-bordered">
+                    <thead>
+                        <tr>
+                            <th>FQDN</th>
+                            <th>State</th>
+                            <th>Provider DNS</th>
+                            <th>Hostname</th>
+                        </tr>
+                    </thead>
+                    <tbody data-bind="foreach: StackHostStore.collection">
+                        <tr>
+                            <td data-bind="text: $data.fqdn"></td>
+                            <td data-bind="text: $data.state"></td>
+                            <td data-bind="text: $data.provider_dns"></td>
+                            <td data-bind="text: $data.hostname"></td>
+                        </tr>     
+                    </tbody>
+                </table>
             </div>
 
             <div class="tab-pane" id="logs" data-bind="visible: editMode() === 'update'">

--- a/stackdio/core/static/stackdio/viewmodel/stack.detail.js
+++ b/stackdio/core/static/stackdio/viewmodel/stack.detail.js
@@ -4,6 +4,7 @@ define([
     'util/galaxy',
     'util/form',
     'store/Stacks',
+    'store/StackHosts',
     'store/Profiles',
     'store/InstanceSizes',
     'store/Blueprints',
@@ -11,7 +12,7 @@ define([
     'store/BlueprintComponents',
     'api/api'
 ],
-function (Q, ko, $galaxy, formutils, StackStore, ProfileStore, InstanceSizeStore, BlueprintStore, BlueprintHostStore, BlueprintComponentStore, API) {
+function (Q, ko, $galaxy, formutils, StackStore, StackHostStore, ProfileStore, InstanceSizeStore, BlueprintStore, BlueprintHostStore, BlueprintComponentStore, API) {
     var vm = function () {
         var self = this;
 
@@ -36,6 +37,7 @@ function (Q, ko, $galaxy, formutils, StackStore, ProfileStore, InstanceSizeStore
         self.provisioningErrorLogText = ko.observable();
 
         self.StackStore = StackStore;
+        self.StackHostStore = StackHostStore;
         self.ProfileStore = ProfileStore;
         self.InstanceSizeStore = InstanceSizeStore;
         self.BlueprintHostStore = BlueprintHostStore;
@@ -137,8 +139,8 @@ function (Q, ko, $galaxy, formutils, StackStore, ProfileStore, InstanceSizeStore
 
                 // Get the hosts for the stack
                 API.StackHosts.load(stack).then(function (hosts) {
-                    stackHosts = hosts;
-                })
+                    self.StackHostStore.add(hosts);
+                });
 
                 // Update observables
                 self.selectedBlueprint(blueprint);


### PR DESCRIPTION
On an existing stack, show host meta data in a separate tab.  Currently shows fqdn, hostname, status, and provider dns
