### PR TITLE
Show total number of history messages regardless of pagination

### DIFF
--- a/stackdio/core/static/stackdio/api/Stacks.js
+++ b/stackdio/core/static/stackdio/api/Stacks.js
@@ -112,6 +112,7 @@ define(['q', 'settings', 'model/models'], function (Q, settings, models) {
             success: function (response) {
                 var history = response.results;
                 stack.fullHistory = history;
+                stack.historyCount = response.count;
                 deferred.resolve(stack);
             },
             error: function (request, status, error) {

--- a/stackdio/core/static/stackdio/view/stacks.html
+++ b/stackdio/core/static/stackdio/view/stacks.html
@@ -45,7 +45,7 @@
                                         content: $root.popoverBuilder($data),
                                         title: 'Stack History'
                                       },
-                                      text: 'View (' + $data.fullHistory.length + ') messages'">
+                                      text: (($data.fullHistory.length >= $data.historyCount) ? $data.fullHistory.length : $data.fullHistory.length + ' of ' + $data.historyCount) + ' messages'">
                         </span>
                     </td>
                     <td>


### PR DESCRIPTION
The text shown in the stack list for "Status History" column now displays "x of y" if the total number of messages is greater than the pagination limit (currently 15)
