### PR TITLE
Need to see the security group name when adding default groups to a provider

### DIFF
--- a/stackdio/core/static/stackdio/view/securityGroups.html
+++ b/stackdio/core/static/stackdio/view/securityGroups.html
@@ -24,7 +24,7 @@
                             class="form-control"
                             data-bind="options: AccountSecurityGroupStore.collection(), 
                                        optionsValue: 'id', 
-                                       optionsText: 'description'",
+                                       optionsText: 'display_name'",
                             data-size="12"
                             data-container="body"></select> 
                 </div>
@@ -61,7 +61,7 @@
 
             <div class="form-group">
                 <div class="lead">Assigned Default Groups</div>
-                <div>To remove any default security groups assigned to this account, click on the 'x' in the label below.</div>
+                <div>To remove any default security groups assigned to this account, click on the label below.</div>
                 <div style="margin: 10px 0 0 0;" id="default_group_list"></div>
             </div>
 

--- a/stackdio/core/static/stackdio/viewmodel/account.securitygroup.js
+++ b/stackdio/core/static/stackdio/viewmodel/account.securitygroup.js
@@ -83,10 +83,10 @@ function (Q, ko, $galaxy, formutils, ProviderTypeStore, AccountStore, ProfileSto
                 self.selectedAccount(account);
 
                 API.SecurityGroups.loadByAccount(account).then(function (data) {
-                    console.log(data);
-
                     for (var group in data.provider_groups) {
-                        self.AccountSecurityGroupStore.add(data.provider_groups[group]);
+                        var thisGroup = data.provider_groups[group];
+                        thisGroup.display_name = thisGroup.name + ' (' + thisGroup.id + ') ' + thisGroup.description;
+                        self.AccountSecurityGroupStore.add(thisGroup);
                     }
 
                     for (group in data.results) {
@@ -94,8 +94,6 @@ function (Q, ko, $galaxy, formutils, ProviderTypeStore, AccountStore, ProfileSto
                             self.DefaultGroupStore.push(data.results[group]);
                         }
                     }
-
-                    console.log('self.DefaultGroupStore',self.DefaultGroupStore());
 
                     self.listDefaultGroups();
                 });


### PR DESCRIPTION
As an admin, when I want to add default security groups, the available groups selectbox is showing the description, and if there's not a good description it's very hard to know which is which.

I'd recommend setting the label to <name> (<id>): <description> or something along those lines.
