### PR TITLE
Provide default orchestration order for components

### DIFF
--- a/stackdio/core/static/stackdio/viewmodel/blueprint.detail.js
+++ b/stackdio/core/static/stackdio/viewmodel/blueprint.detail.js
@@ -252,8 +252,6 @@ function (Q, ko, $galaxy, formutils, HostVolumeStore, HostRuleStore, AccountStor
                 });
             });
 
-            // return;
-
             properties = JSON.parse(document.getElementById('blueprint_properties').value) || '';
 
             var blueprint = {

--- a/stackdio/core/static/stackdio/viewmodel/host.detail.js
+++ b/stackdio/core/static/stackdio/viewmodel/host.detail.js
@@ -201,6 +201,9 @@ function (Q, ko, $galaxy, formutils, AccountStore, ProfileStore, FormulaStore, I
                     return comp.id === componentId;
                 });
 
+                // Provide a default component orchestration order of 0
+                component.order = 0;
+
                 if (typeof _.findWhere(BlueprintComponentStore.collection(), { id: component.id }) === "undefined") {
                     BlueprintComponentStore.add(component);
                 }


### PR DESCRIPTION
When user adds a host to a blueprint, and formula components selected by the user will be given a default orchestration order of 0, which can then be overridden in the UI before saving the blueprint
