### PR TITLE
Create sudoer file without dots

### DIFF
--- a/stackdio/stackdio/management/saltdirs/core_states/core/stackdio_user.sls
+++ b/stackdio/stackdio/management/saltdirs/core_states/core/stackdio_user.sls
@@ -32,7 +32,7 @@ stackdio_authorized_keys:
 # Add a sudoers entry
 stackdio_sudoers:
   file.managed:
-    - name: /etc/sudoers.d/{{ username }}
+    - name: /etc/sudoers.d/stackdio_user
     - contents: "{{ username }}  ALL=(ALL)  NOPASSWD:ALL"
     - mode: 400
     - user: root


### PR DESCRIPTION
Fixes the issue with stackd.io users that have dots in their username
