### PR TITLE
removed unnecessary section

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -204,7 +204,3 @@ The superuser we created earlier will give us admin access to stackd.io, however
 * optionally provide first name, last name, and email address of the user and click save
 
 The newly created users will now have access to stackd.io. Test this by logging out and signing in with one of the non-admin users.
-
-# Next steps
-
-This concludes the quick start. At this point you should have a running stackd.io install, but you may need a bit more help in using the system. You can read through the [stackd.io tutorial](tutorial.md) or watch the [stackd.io screencast](http://stackd.io/tour) to learn a bit more about using the system to manage your cloud infrastructure.


### PR DESCRIPTION
The "Next Steps" section was mostly to provide a link to "tutorial.md" (does not exist) and a link to a screencast at stackd.io/tour (where there is no screen cast).