### PR TITLE
Various bugfixes from 0.7.0rc3

### DIFF
--- a/packer/build.json
+++ b/packer/build.json
@@ -4,7 +4,7 @@
         "source_ami": "ami-767a391e",
         "aws_access_key": "{{ env `AWS_ACCESS_KEY` }}",
         "aws_secret_key": "{{ env `AWS_SECRET_KEY` }}",
-        "packages": "python python-dev python-virtualenv mysql-server mysql-client libssl-dev libncurses5-dev swig libmysqlclient-dev rabbitmq-server git nginx libldap2-dev libsasl2-dev"
+        "packages": "python python-dev python-virtualenv mysql-server mysql-client libssl-dev libncurses5-dev swig libmysqlclient-dev rabbitmq-server git nginx libldap2-dev libsasl2-dev ntp ntpdate ntp-doc"
     },
     "builders": [
         {

--- a/packer/install.sh
+++ b/packer/install.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+# Need to stop ntp before syncing
+service ntp stop || echo 'ntp already stopped'
+ntpdate 0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org 3.pool.ntp.org
+service ntp start
+
 # Create the stackdio user
 useradd -m -s/bin/bash -U stackdio
 

--- a/packer/supervisord.conf
+++ b/packer/supervisord.conf
@@ -37,7 +37,7 @@ history_file=~/.sc_history
 ;;
 ;; django webserver
 [program:gunicorn]
-command=gunicorn stackdio.server.wsgi -b 127.0.0.1:8000
+command=gunicorn stackdio.server.wsgi -b 127.0.0.1:8000 -w 4
 autorestart=true
 
 

--- a/stackdio/api/blueprints/api.py
+++ b/stackdio/api/blueprints/api.py
@@ -82,9 +82,9 @@ class BlueprintDetailAPIView(generics.RetrieveUpdateDestroyAPIView):
         stacks = [s.title for s in instance.stacks.all()]
         if stacks:
             raise ValidationError({
-                'detail': 'This blueprint is in use by one or more '
-                          'stacks and cannot be removed.',
-                'stacks': stacks
+                'detail': ['This blueprint is in use by one or more '
+                           'stacks and cannot be removed.'],
+                'stacks': stacks,
             })
 
         # The blueprint isn't being used, so delete it

--- a/stackdio/api/blueprints/filters.py
+++ b/stackdio/api/blueprints/filters.py
@@ -18,14 +18,17 @@
 
 import django_filters
 
+from stackdio.core.filters import OrFieldsFilter
 from . import models
 
 
 class BlueprintFilter(django_filters.FilterSet):
     title = django_filters.CharFilter(lookup_type='icontains')
+    q = OrFieldsFilter(field_names=('title', 'description'), lookup_type='icontains')
 
     class Meta:
         model = models.Blueprint
         fields = (
             'title',
+            'q',
         )

--- a/stackdio/api/cloud/api.py
+++ b/stackdio/api/cloud/api.py
@@ -302,6 +302,7 @@ class SnapshotListAPIView(generics.ListCreateAPIView):
     serializer_class = serializers.SnapshotSerializer
     permission_classes = (StackdioModelPermissions,)
     filter_backends = (DjangoObjectPermissionsFilter, DjangoFilterBackend)
+    filter_class = filters.SnapshotFilter
 
     def perform_create(self, serializer):
         snapshot = serializer.save()

--- a/stackdio/api/cloud/filters.py
+++ b/stackdio/api/cloud/filters.py
@@ -17,28 +17,35 @@
 
 import django_filters
 
+from stackdio.core.filters import OrFieldsFilter
 from . import models
 
 
 class CloudAccountFilter(django_filters.FilterSet):
     title = django_filters.CharFilter(lookup_type='icontains')
     region = django_filters.CharFilter(name='region__title')
+    q = OrFieldsFilter(field_names=('title', 'description', 'region__title', 'vpc_id'),
+                       lookup_type='icontains')
 
     class Meta:
         model = models.CloudAccount
         fields = (
             'title',
             'region',
+            'q',
         )
 
 
 class CloudImageFilter(django_filters.FilterSet):
     title = django_filters.CharFilter(lookup_type='icontains')
+    q = OrFieldsFilter(field_names=('title', 'description', 'image_id'),
+                       lookup_type='icontains')
 
     class Meta:
         model = models.CloudImage
         fields = (
             'title',
+            'q',
         )
 
 
@@ -87,4 +94,18 @@ class SecurityGroupFilter(django_filters.FilterSet):
             'description',
             'default',
             'managed',
+        )
+
+
+class SnapshotFilter(django_filters.FilterSet):
+    title = django_filters.CharFilter(lookup_type='icontains')
+    q = OrFieldsFilter(field_names=('title', 'description', 'snapshot_id', 'size_in_gb',
+                                    'filesystem_type'),
+                       lookup_type='icontains')
+
+    class Meta:
+        model = models.Snapshot
+        fields = (
+            'title',
+            'q',
         )

--- a/stackdio/api/formulas/filters.py
+++ b/stackdio/api/formulas/filters.py
@@ -18,12 +18,15 @@
 
 import django_filters
 
+from stackdio.core.filters import OrFieldsFilter
 from . import models
 
 
 class FormulaFilter(django_filters.FilterSet):
     title = django_filters.CharFilter(lookup_type='icontains')
     component = django_filters.CharFilter(name='components__sls_path')
+    q = OrFieldsFilter(field_names=('title', 'description', 'uri', 'root_path'),
+                       lookup_type='icontains')
 
     class Meta:
         model = models.Formula
@@ -32,4 +35,5 @@ class FormulaFilter(django_filters.FilterSet):
             'uri',
             'root_path',
             'component',
+            'q',
         )

--- a/stackdio/api/formulas/urls.py
+++ b/stackdio/api/formulas/urls.py
@@ -40,33 +40,33 @@ object_router.register(r'groups',
 
 
 urlpatterns = (
-    url(r'^formulas/$',
+    url(r'^$',
         api.FormulaListAPIView.as_view(),
         name='formula-list'),
 
-    url(r'^formulas/permissions/',
+    url(r'^permissions/',
         include(model_router.urls)),
 
-    url(r'^formulas/(?P<pk>[0-9]+)/$',
+    url(r'^(?P<pk>[0-9]+)/$',
         api.FormulaDetailAPIView.as_view(),
         name='formula-detail'),
 
-    url(r'^formulas/(?P<pk>[0-9]+)/properties/$',
+    url(r'^(?P<pk>[0-9]+)/properties/$',
         api.FormulaPropertiesAPIView.as_view(),
         name='formula-properties'),
 
-    url(r'^formulas/(?P<pk>[0-9]+)/components/$',
+    url(r'^(?P<pk>[0-9]+)/components/$',
         api.FormulaComponentListAPIView.as_view(),
         name='formula-component-list'),
 
-    url(r'^formulas/(?P<pk>[0-9]+)/valid_versions/$',
+    url(r'^(?P<pk>[0-9]+)/valid_versions/$',
         api.FormulaValidVersionListAPIView.as_view(),
         name='formula-valid-version-list'),
 
-    url(r'^formulas/(?P<pk>[0-9]+)/action/$',
+    url(r'^(?P<pk>[0-9]+)/action/$',
         api.FormulaActionAPIView.as_view(),
         name='formula-action'),
 
-    url(r'^formulas/(?P<pk>[0-9]+)/permissions/',
+    url(r'^(?P<pk>[0-9]+)/permissions/',
         include(object_router.urls)),
 )

--- a/stackdio/api/search/urls.py
+++ b/stackdio/api/search/urls.py
@@ -21,7 +21,7 @@ from django.conf.urls import url
 from . import api
 
 urlpatterns = (
-    url(r'^search/$',
+    url(r'^$',
         api.SearchAPIView.as_view(),
         name='search'),
 )

--- a/stackdio/api/stacks/api.py
+++ b/stackdio/api/stacks/api.py
@@ -341,7 +341,8 @@ class StackHostsAPIView(mixins.StackRelatedMixin, generics.ListCreateAPIView):
         We need the stack during serializer validation - so we'll throw it in the context
         """
         context = super(StackHostsAPIView, self).get_serializer_context()
-        context['stack'] = self.get_stack()
+        # No need to check perms - that happens in get_queryset
+        context['stack'] = self.get_stack(check_permissions=False)
         return context
 
 

--- a/stackdio/api/stacks/filters.py
+++ b/stackdio/api/stacks/filters.py
@@ -18,21 +18,27 @@
 
 import django_filters
 
+from stackdio.core.filters import OrFieldsFilter
 from . import models
 
 
 class StackFilter(django_filters.FilterSet):
     title = django_filters.CharFilter(lookup_type='icontains')
+    q = OrFieldsFilter(field_names=('title', 'description', 'namespace'), lookup_type='icontains')
 
     class Meta:
         model = models.Stack
         fields = (
             'title',
+            'q',
         )
 
 
 class HostFilter(django_filters.FilterSet):
     hostname = django_filters.CharFilter(lookup_type='icontains')
+    q = OrFieldsFilter(field_names=('title', 'description', 'hostname', 'instance_id',
+                                    'provider_private_ip'),
+                       lookup_type='icontains')
 
     class Meta:
         model = models.Host
@@ -40,4 +46,5 @@ class HostFilter(django_filters.FilterSet):
             'hostname',
             'status',
             'state',
+            'q',
         )

--- a/stackdio/api/stacks/mixins.py
+++ b/stackdio/api/stacks/mixins.py
@@ -23,11 +23,12 @@ from . import models, permissions
 class StackRelatedMixin(object):
     permission_classes = (permissions.StackParentObjectPermissions,)
 
-    def get_stack(self):
+    def get_stack(self, check_permissions=True):
         queryset = models.Stack.objects.all()
 
         obj = get_object_or_404(queryset, id=self.kwargs.get('pk'))
-        self.check_object_permissions(self.request, obj)
+        if check_permissions:
+            self.check_object_permissions(self.request, obj)
         return obj
 
     def get_permissioned_object(self):

--- a/stackdio/api/stacks/models.py
+++ b/stackdio/api/stacks/models.py
@@ -42,8 +42,6 @@ from model_utils.models import StatusModel
 from stackdio.core.fields import DeletingFileField
 from stackdio.core.utils import recursive_update
 from stackdio.api.cloud.models import SecurityGroup
-from stackdio.api.formulas.models import FormulaVersion
-from stackdio.api.formulas.tasks import update_formula
 
 PROTOCOL_CHOICES = [
     ('tcp', 'TCP'),
@@ -757,6 +755,10 @@ class Stack(TimeStampedModel, TitleSlugDescriptionModel, StatusModel):
                 f.write(yaml_data)
 
     def generate_pillar_file(self, update_formulas=False):
+        # Import here to not cause circular imports
+        from stackdio.api.formulas.models import FormulaVersion
+        from stackdio.api.formulas.tasks import update_formula
+
         users = []
         # pull the create_ssh_users property from the stackd.io config file.
         # If it's False, we won't create ssh users on the box.
@@ -833,6 +835,10 @@ class Stack(TimeStampedModel, TitleSlugDescriptionModel, StatusModel):
                 f.write(pillar_file_yaml)
 
     def generate_global_pillar_file(self, update_formulas=False):
+        # Import here to not cause circular imports
+        from stackdio.api.formulas.models import FormulaVersion
+        from stackdio.api.formulas.tasks import update_formula
+
         pillar_props = {}
 
         # Find all of the globally used formulas for the stack

--- a/stackdio/api/stacks/tasks.py
+++ b/stackdio/api/stacks/tasks.py
@@ -181,7 +181,7 @@ def launch_hosts(stack_id, parallel=True, max_retries=2,
         log_file = utils.get_salt_cloud_log_file(stack, 'launch')
 
         # Generate the pillar file.  We need it!
-        stack.generate_pillar_file()
+        stack.generate_pillar_file(update_formulas=True)
 
         logger.info('Launching hosts for stack: {0!r}'.format(stack))
         logger.info('Log file: {0}'.format(log_file))
@@ -846,8 +846,8 @@ def sync_all(stack_id):
         logger.info('Syncing all salt systems for stack: {0!r}'.format(stack))
 
         # Generate all the files before we sync
-        stack.generate_pillar_file()
-        stack.generate_global_pillar_file()
+        stack.generate_pillar_file(update_formulas=True)
+        stack.generate_global_pillar_file(update_formulas=True)
         stack.generate_top_file()
         stack.generate_orchestrate_file()
         stack.generate_global_orchestrate_file()
@@ -1089,7 +1089,7 @@ def propagate_ssh(stack_id, max_retries=2):
         stack = Stack.objects.get(id=stack_id)
         target = [h.hostname for h in stack.get_hosts()]
         # Regenerate the stack pillar file
-        stack.generate_pillar_file()
+        stack.generate_pillar_file(update_formulas=True)
         num_hosts = len(stack.get_hosts())
         logger.info('Propagating ssh keys on stack: {0!r}'.format(stack))
 

--- a/stackdio/api/stacks/utils.py
+++ b/stackdio/api/stacks/utils.py
@@ -417,8 +417,8 @@ def process_orchestrate_result(result, stack, log_file, err_file):
     for sls, sls_result in sorted(result.items(), key=lambda x: x[1]['__run_num__']):
         sls_dict = state_to_dict(sls)
 
-        logger.info('Processing stage {0} for stack {1}'.format(sls_dict['name'],
-                                                                stack.title))
+        logger.info('Processing stage {0} for stack {1}\n'.format(sls_dict['name'],
+                                                                  stack.title))
 
         with open(err_file, 'a') as f:
             if 'changes' in sls_result and 'ret' in sls_result['changes']:
@@ -434,7 +434,7 @@ def process_orchestrate_result(result, stack, log_file, err_file):
                 ))
             else:
                 f.write(
-                    'Stage {0} appears to have no changes, but it failed.  See below.\n\n'.format(
+                    'Stage {0} appears to have no changes, but it failed.  See below.\n'.format(
                         sls_dict['name']
                     )
                 )
@@ -447,9 +447,9 @@ def process_orchestrate_result(result, stack, log_file, err_file):
         with open(err_file, 'a') as f:
             comment = sls_result['comment']
             if isinstance(comment, six.string_types):
-                f.write(COLOR_REGEX.sub('', comment))
+                f.write('{0}\n\n'.format(COLOR_REGEX.sub('', comment)))
             else:
-                f.write(yaml.safe_dump(comment))
+                f.write('{0}\n\n'.format(yaml.safe_dump(comment)))
         local_failed, local_failed_hosts = process_sls_result(sls_result['changes'], err_file)
 
         if local_failed:

--- a/stackdio/api/urls.py
+++ b/stackdio/api/urls.py
@@ -79,6 +79,8 @@ def api_not_found_view(request, *args, **kwargs):
     return Response({'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND)
 
 
+# This is our custom 404 handler so that 404 requests to /api endpoints return JSON instead
+# of the default 404 page
 def api_not_found(request, *args, **kwargs):
     if request.path.startswith('/api'):
         ret = api_not_found_view(request, *args, **kwargs)
@@ -98,10 +100,10 @@ urlpatterns = (
     url(r'^', include('stackdio.api.users.urls', namespace='users')),
     url(r'^cloud/', include('stackdio.api.cloud.urls', namespace='cloud')),
     url(r'^blueprints/', include('stackdio.api.blueprints.urls', namespace='blueprints')),
-    url(r'^', include('stackdio.api.formulas.urls', namespace='formulas')),
+    url(r'^formulas/', include('stackdio.api.formulas.urls', namespace='formulas')),
     url(r'^', include('stackdio.api.stacks.urls', namespace='stacks')),
-    url(r'^', include('stackdio.api.volumes.urls', namespace='volumes')),
-    url(r'^', include('stackdio.api.search.urls', namespace='search')),
+    url(r'^volumes/', include('stackdio.api.volumes.urls', namespace='volumes')),
+    url(r'^search/', include('stackdio.api.search.urls', namespace='search')),
 )
 
 # Format suffixes - this only should go on API endpoints, not everything!

--- a/stackdio/api/urls.py
+++ b/stackdio/api/urls.py
@@ -76,7 +76,7 @@ class APIRootView(APIView):
 
 @api_view(APIView.http_method_names)
 def api_not_found_view(request, *args, **kwargs):
-    return Response({'detail': 'Not Found'}, status=status.HTTP_404_NOT_FOUND)
+    return Response({'detail': 'Not found.'}, status=status.HTTP_404_NOT_FOUND)
 
 
 def api_not_found(request, *args, **kwargs):

--- a/stackdio/api/urls.py
+++ b/stackdio/api/urls.py
@@ -15,8 +15,10 @@
 # limitations under the License.
 #
 
+from __future__ import unicode_literals
 
 from django.conf.urls import include, url
+from django.http import Http404
 
 from rest_framework.compat import OrderedDict
 from rest_framework.response import Response
@@ -70,6 +72,30 @@ class APIRootView(APIView):
         return Response(api)
 
 
+class APINotFoundView(APIView):
+
+    def get(self, request, *args, **kwargs):
+        raise Http404
+
+    def post(self, request, *args, **kwargs):
+        return self.get(request, *args, **kwargs)
+
+    def put(self, request, *args, **kwargs):
+        return self.get(request, *args, **kwargs)
+
+    def patch(self, request, *args, **kwargs):
+        return self.get(request, *args, **kwargs)
+
+    def delete(self, request, *args, **kwargs):
+        return self.get(request, *args, **kwargs)
+
+    def head(self, request, *args, **kwargs):
+        return self.get(request, *args, **kwargs)
+
+    def trace(self, request, *args, **kwargs):
+        return self.get(request, *args, **kwargs)
+
+
 urlpatterns = (
     url(r'^$', APIRootView.as_view(), name='root'),
 
@@ -83,6 +109,7 @@ urlpatterns = (
     url(r'^', include('stackdio.api.stacks.urls', namespace='stacks')),
     url(r'^', include('stackdio.api.volumes.urls', namespace='volumes')),
     url(r'^', include('stackdio.api.search.urls', namespace='search')),
+    url(r'^.*$', APINotFoundView.as_view(), name='404'),
 )
 
 # Format suffixes - this only should go on API endpoints, not everything!

--- a/stackdio/api/users/api.py
+++ b/stackdio/api/users/api.py
@@ -20,6 +20,7 @@ from django.contrib.auth import get_user_model, update_session_auth_hash
 from django.contrib.auth.models import Group
 from django_auth_ldap.backend import LDAPBackend
 from rest_framework import generics
+from rest_framework.filters import DjangoFilterBackend, DjangoObjectPermissionsFilter
 from rest_framework.response import Response
 
 from stackdio.core.permissions import StackdioModelPermissions
@@ -37,6 +38,7 @@ class UserListAPIView(generics.ListCreateAPIView):
     serializer_class = serializers.PublicUserSerializer
     permission_classes = (StackdioModelPermissions,)
     lookup_field = 'username'
+    filter_backends = (DjangoObjectPermissionsFilter, DjangoFilterBackend)
     filter_class = filters.UserFilter
 
     def get_queryset(self):
@@ -79,6 +81,7 @@ class GroupListAPIView(generics.ListCreateAPIView):
     serializer_class = serializers.GroupSerializer
     permission_classes = (StackdioModelPermissions,)
     lookup_field = 'name'
+    filter_backends = (DjangoObjectPermissionsFilter, DjangoFilterBackend)
     filter_class = filters.GroupFilter
 
 
@@ -132,14 +135,14 @@ class GroupModelGroupPermissionsViewSet(StackdioModelGroupPermissionsViewSet):
 class GroupObjectUserPermissionsViewSet(mixins.GroupRelatedMixin,
                                         StackdioObjectUserPermissionsViewSet):
     permission_classes = (permissions.GroupPermissionsObjectPermissions,)
-    object_permissions = ('update', 'delete', 'admin')
+    object_permissions = ('update', 'delete', 'admin', 'view')
     parent_lookup_field = 'name'
 
 
 class GroupObjectGroupPermissionsViewSet(mixins.GroupRelatedMixin,
                                          StackdioObjectGroupPermissionsViewSet):
     permission_classes = (permissions.GroupPermissionsObjectPermissions,)
-    object_permissions = ('update', 'delete', 'admin')
+    object_permissions = ('update', 'delete', 'admin', 'view')
     parent_lookup_field = 'name'
 
 

--- a/stackdio/api/users/apps.py
+++ b/stackdio/api/users/apps.py
@@ -28,8 +28,8 @@ from django.utils.translation import ugettext_lazy as _
 logger = logging.getLogger(__name__)
 
 
-EXTRA_USER_PERMS = ('admin', 'create')
-EXTRA_GROUP_PERMS = ('admin', 'create', 'update')
+EXTRA_USER_PERMS = ('admin', 'create', 'view')
+EXTRA_GROUP_PERMS = ('admin', 'create', 'update', 'view')
 
 
 def create_extra_permissions(app_config, verbosity=2, interactive=True,

--- a/stackdio/api/users/filters.py
+++ b/stackdio/api/users/filters.py
@@ -20,11 +20,15 @@ import django_filters
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 
+from stackdio.core.filters import OrFieldsFilter
+
 
 class UserFilter(django_filters.FilterSet):
     username = django_filters.CharFilter(lookup_type='icontains')
     first_name = django_filters.CharFilter(lookup_type='icontains')
     last_name = django_filters.CharFilter(lookup_type='icontains')
+    q = OrFieldsFilter(field_names=('username', 'first_name', 'last_name', 'email'),
+                       lookup_type='icontains')
 
     class Meta:
         model = get_user_model()
@@ -32,14 +36,17 @@ class UserFilter(django_filters.FilterSet):
             'username',
             'first_name',
             'last_name',
+            'q',
         )
 
 
 class GroupFilter(django_filters.FilterSet):
     name = django_filters.CharFilter(lookup_type='icontains')
+    q = OrFieldsFilter(field_names=('name',), lookup_type='icontains')
 
     class Meta:
         model = Group
         fields = (
             'name',
+            'q',
         )

--- a/stackdio/api/volumes/filters.py
+++ b/stackdio/api/volumes/filters.py
@@ -18,14 +18,18 @@
 
 import django_filters
 
+from stackdio.core.filters import OrFieldsFilter
 from . import models
 
 
 class VolumeFilter(django_filters.FilterSet):
     stack = django_filters.CharFilter(name='stack__title', lookup_type='icontains')
+    q = OrFieldsFilter(field_names=('stack__title', 'hostname', 'snapshot__title'),
+                       lookup_type='icontains')
 
     class Meta:
         model = models.Volume
         fields = (
             'stack',
+            'q',
         )

--- a/stackdio/api/volumes/urls.py
+++ b/stackdio/api/volumes/urls.py
@@ -40,17 +40,17 @@ object_router.register(r'groups',
 
 
 urlpatterns = (
-    url(r'^volumes/$',
+    url(r'^$',
         api.VolumeListAPIView.as_view(),
         name='volume-list'),
 
-    url(r'^volumes/permissions/',
+    url(r'^permissions/',
         include(model_router.urls)),
 
-    url(r'^volumes/(?P<pk>[0-9]+)/$',
+    url(r'^(?P<pk>[0-9]+)/$',
         api.VolumeDetailAPIView.as_view(),
         name='volume-detail'),
 
-    url(r'^volumes/(?P<pk>[0-9]+)/permissions/',
+    url(r'^(?P<pk>[0-9]+)/permissions/',
         include(object_router.urls)),
 )

--- a/stackdio/core/filters.py
+++ b/stackdio/core/filters.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2014,  Digital Reasoning
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from operator import or_
+
+import django_filters
+import six
+from django.db.models import Q
+from django_filters.fields import Lookup
+
+
+class OrFieldsFilter(django_filters.Filter):
+
+    def __init__(self, *args, **kwargs):
+        field_names = kwargs.pop('field_names', ())
+        self.field_names = field_names
+        super(OrFieldsFilter, self).__init__(*args, **kwargs)
+
+    def filter(self, qs, value):
+        if isinstance(value, Lookup):
+            lookup = six.text_type(value.lookup_type)
+            value = value.value
+        else:
+            lookup = self.lookup_type
+        if value in ([], (), {}, None, ''):
+            return qs
+
+        q_objects = []
+        for field in self.field_names:
+            q_objects.append(Q(**{'%s__%s' % (field, lookup): value}))
+
+        qs = self.get_method(qs)(reduce(or_, q_objects))
+        if self.distinct:
+            qs = qs.distinct()
+        return qs

--- a/stackdio/core/permissions.py
+++ b/stackdio/core/permissions.py
@@ -78,6 +78,25 @@ class StackdioParentObjectPermissions(StackdioObjectPermissions):
 
     parent_model_cls = None
 
+    def has_permission(self, request, view):
+        """
+        Since this is for 'parent' object permissions, override this to check permissions on
+        the parent object.
+        """
+        try:
+            model_name = self.parent_model_cls._meta.model_name
+        except AttributeError:
+            return False
+
+        # Grab the get_object method
+        get_object_method = getattr(view, 'get_%s' % model_name, None)
+
+        # Couldn't find a method, no permission granted
+        if get_object_method is None:
+            return False
+
+        return self.has_object_permission(request, view, get_object_method())
+
     def has_object_permission(self, request, view, obj):
         assert self.parent_model_cls is not None, (
             'Cannot apply %s directly. '

--- a/stackdio/core/templates/stackdio/base.html
+++ b/stackdio/core/templates/stackdio/base.html
@@ -22,7 +22,9 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+
     <title>stackd.io | {% block title %}Home{% endblock %}</title>
+    <meta name="description" content="{% block description %}a modern cloud deployment and provisioning framework for everyone{% endblock %}">
 
     {% include 'stackdio/favicons.html' %}
 
@@ -35,8 +37,6 @@
 
     <!-- extra stylesheets -->
     {% block stylesheets %}{% endblock %}
-
-    <meta name="description" content="stackd.io | a modern cloud deployment and provisioning framework for everyone">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/stackdio/server/urls.py
+++ b/stackdio/server/urls.py
@@ -17,11 +17,12 @@
 
 
 from django.conf.urls import include, url
+from django.contrib import admin
+
+from stackdio.api.urls import api_not_found
 
 # Enable admin interface
-from django.contrib import admin
 admin.autodiscover()
-
 
 urlpatterns = (
     # Admin interface
@@ -40,3 +41,6 @@ urlpatterns = (
     # in the browsable api.
     url(r'^api/', include('rest_framework.urls', namespace='rest_framework'))
 )
+
+# Override the default 404 handler
+handler404 = api_not_found

--- a/stackdio/server/urls.py
+++ b/stackdio/server/urls.py
@@ -25,21 +25,21 @@ from stackdio.api.urls import api_not_found
 admin.autodiscover()
 
 urlpatterns = (
-    # Admin interface
-    url(r'^__private/admin/', include(admin.site.urls)),
-
     # Grab the core URLs.  Basically just the version endpoint.
     url(r'^', include('stackdio.core.urls', namespace='stackdio')),
-
-    # Grab the ui URLs.  Stuff like index, login, logout, etc
-    url(r'^', include('stackdio.ui.urls', namespace='ui')),
 
     # API v1 root endpoint -- add additional URLs to urls.py in the api module.
     url(r'^api/', include('stackdio.api.urls', namespace='api')),
 
     # Default login/logout views. Without this you won't get the login/logout links
     # in the browsable api.
-    url(r'^api/', include('rest_framework.urls', namespace='rest_framework'))
+    url(r'^api/', include('rest_framework.urls', namespace='rest_framework')),
+
+    # Grab the ui URLs.  Stuff like index, login, logout, etc
+    url(r'^', include('stackdio.ui.urls', namespace='ui')),
+
+    # Admin interface
+    url(r'^__private/admin/', include(admin.site.urls)),
 )
 
 # Override the default 404 handler

--- a/stackdio/ui/static/stackdio/app/generics/formula-versions.js
+++ b/stackdio/ui/static/stackdio/app/generics/formula-versions.js
@@ -35,6 +35,7 @@ define([
         model: FormulaVersion,
         baseUrl: null,
         initialUrl: null,
+        versionsReady: ko.observable(false),
         sortableFields: [
             {name: 'formula', displayName: 'Formula', width: '60%'},
             {name: 'version', displayName: 'Version', width: '40%'}
@@ -57,6 +58,8 @@ define([
             markForRemoval.forEach(function (version) {
                 self.objects.remove(version);
             });
+
+            this.versionsReady(true);
         },
         extraReloadSteps: function () {
             if (this.formulas) {

--- a/stackdio/ui/static/stackdio/app/generics/formula-versions.js
+++ b/stackdio/ui/static/stackdio/app/generics/formula-versions.js
@@ -35,7 +35,7 @@ define([
         model: FormulaVersion,
         baseUrl: null,
         initialUrl: null,
-        versionsReady: ko.observable(false),
+        versionsReady: ko.observable(!window.stackdio.hasUpdatePerm),
         sortableFields: [
             {name: 'formula', displayName: 'Formula', width: '60%'},
             {name: 'version', displayName: 'Version', width: '40%'}
@@ -62,15 +62,17 @@ define([
             this.versionsReady(true);
         },
         extraReloadSteps: function () {
-            if (this.formulas) {
-                this.createSelectors();
-            } else {
-                // We don't have the formulas yet, we need to grab them
-                var self = this;
-                versionUtils.getAllFormulas(function (formulas) {
-                    self.formulas = formulas;
-                    self.createSelectors();
-                });
+            if (window.stackdio.hasUpdatePerm) {
+                if (this.formulas) {
+                    this.createSelectors();
+                } else {
+                    // We don't have the formulas yet, we need to grab them
+                    var self = this;
+                    versionUtils.getAllFormulas(function (formulas) {
+                        self.formulas = formulas;
+                        self.createSelectors();
+                    });
+                }
             }
         },
         saveVersions: function () {

--- a/stackdio/ui/static/stackdio/app/generics/formula-versions.js
+++ b/stackdio/ui/static/stackdio/app/generics/formula-versions.js
@@ -45,8 +45,17 @@ define([
         },
         createSelectors: function () {
             var self = this;
+            var markForRemoval = [];
             this.objects().forEach(function (version) {
-                versionUtils.createVersionSelector(version, self.formulas);
+                if (!versionUtils.createVersionSelector(version, self.formulas)) {
+                    // We don't have permission, add it to the removal list
+                    markForRemoval.push(version);
+                }
+            });
+
+            // Get rid of ones we don't have permission to see
+            markForRemoval.forEach(function (version) {
+                self.objects.remove(version);
             });
         },
         extraReloadSteps: function () {

--- a/stackdio/ui/static/stackdio/app/generics/pagination.js
+++ b/stackdio/ui/static/stackdio/app/generics/pagination.js
@@ -135,7 +135,7 @@ define([
             }, this);
 
             if (this.autoRefresh) {
-                setInterval((function (self) {
+                this.intervalId = setInterval((function (self) {
                     return function() {
                         self.reload();
                     }
@@ -237,9 +237,14 @@ define([
                 }));
 
                 self.extraReloadSteps();
-            }).fail(function () {
-                // If we get a 404 or something, reset EVERYTHING.
-                self.reset();
+            }).fail(function (jqxhr) {
+                if (jqxhr.status == 403) {
+                    // On 403, we should reload, which SHOULD redirect to the login page
+                    window.location.reload(true);
+                } else {
+                    // If we get a 404 or something else, reset EVERYTHING.
+                    self.reset();
+                }
             }).always(function () {
                 self.loading(false);
             });

--- a/stackdio/ui/static/stackdio/app/generics/pagination.js
+++ b/stackdio/ui/static/stackdio/app/generics/pagination.js
@@ -45,6 +45,8 @@ define([
         sortKey: ko.observable(),
         sortAsc: ko.observable(true),
 
+        permissionsMap: window.stackdio.permissionsMap,
+
         // Computed observables, to be created in init()
         sortedObjects: null,
         startNum: null,

--- a/stackdio/ui/static/stackdio/app/generics/pagination.js
+++ b/stackdio/ui/static/stackdio/app/generics/pagination.js
@@ -68,7 +68,7 @@ define([
             $searchBar.search();
 
             $searchBar.on('searched.fu.search', function () {
-                self.currentPage(self.initialUrl + '?title=' + self.searchInput.val());
+                self.currentPage(self.initialUrl + '?q=' + self.searchInput.val());
                 self.shouldReset = false;
                 self.reset();
             });

--- a/stackdio/ui/static/stackdio/app/generics/pagination.js
+++ b/stackdio/ui/static/stackdio/app/generics/pagination.js
@@ -18,7 +18,8 @@
 define([
     'jquery',
     'knockout',
-    'utils/class'
+    'utils/class',
+    'fuelux'
 ], function ($, ko, Class) {
     'use strict';
     

--- a/stackdio/ui/static/stackdio/app/models/blueprint.js
+++ b/stackdio/ui/static/stackdio/app/models/blueprint.js
@@ -202,7 +202,6 @@ define([
                     }).fail(function (jqxhr) {
                         var message;
                         try {
-                            console.log(jqxhr.responseText);
                             var resp = JSON.parse(jqxhr.responseText);
                             message = resp.detail.join('<br>');
                             if (Object.keys(resp).indexOf('stacks') >= 0) {

--- a/stackdio/ui/static/stackdio/app/models/blueprint.js
+++ b/stackdio/ui/static/stackdio/app/models/blueprint.js
@@ -193,8 +193,12 @@ define([
                     $.ajax({
                         method: 'DELETE',
                         url: self.raw.url
-                    }).done(function (blueprint) {
-                        // Nothing to do here?
+                    }).done(function () {
+                        if (window.location.pathname !== '/blueprints/') {
+                            window.location = '/blueprints/';
+                        } else if (self.parent && typeof self.parent.reload === 'function') {
+                            self.parent.reload();
+                        }
                     }).fail(function (jqxhr) {
                         var message;
                         try {

--- a/stackdio/ui/static/stackdio/app/models/blueprint.js
+++ b/stackdio/ui/static/stackdio/app/models/blueprint.js
@@ -202,8 +202,12 @@ define([
                     }).fail(function (jqxhr) {
                         var message;
                         try {
+                            console.log(jqxhr.responseText);
                             var resp = JSON.parse(jqxhr.responseText);
                             message = resp.detail.join('<br>');
+                            if (Object.keys(resp).indexOf('stacks') >= 0) {
+                                message += '<br><br>Stacks:<ul><li>' + resp.stacks.join('</li><li>') + '</li></ul>';
+                            }
                         } catch (e) {
                             message = 'Oops... there was a server error.  This has been reported ' +
                                 'to your administrators.';

--- a/stackdio/ui/static/stackdio/app/models/cloud-account.js
+++ b/stackdio/ui/static/stackdio/app/models/cloud-account.js
@@ -200,8 +200,12 @@ define([
                     $.ajax({
                         method: 'DELETE',
                         url: self.raw.url
-                    }).done(function (account) {
-                        // Nothing to do here?
+                    }).done(function () {
+                        if (window.location.pathname !== '/accounts/') {
+                            window.location = '/accounts/';
+                        } else if (self.parent && typeof self.parent.reload === 'function') {
+                            self.parent.reload();
+                        }
                     }).fail(function (jqxhr) {
                         var message;
                         try {

--- a/stackdio/ui/static/stackdio/app/models/cloud-image.js
+++ b/stackdio/ui/static/stackdio/app/models/cloud-image.js
@@ -134,8 +134,12 @@ define([
                     $.ajax({
                         method: 'DELETE',
                         url: self.raw.url
-                    }).done(function (image) {
-                        // Nothing to do here?
+                    }).done(function () {
+                        if (window.location.pathname !== '/images/') {
+                            window.location = '/images/';
+                        } else if (self.parent && typeof self.parent.reload === 'function') {
+                            self.parent.reload();
+                        }
                     }).fail(function (jqxhr) {
                         var message;
                         try {

--- a/stackdio/ui/static/stackdio/app/models/formula.js
+++ b/stackdio/ui/static/stackdio/app/models/formula.js
@@ -291,8 +291,12 @@ define([
                     $.ajax({
                         method: 'DELETE',
                         url: self.raw.url
-                    }).done(function (formula) {
-                        // Nothing to do here?
+                    }).done(function () {
+                        if (window.location.pathname !== '/formulas/') {
+                            window.location = '/formulas/';
+                        } else if (self.parent && typeof self.parent.reload === 'function') {
+                            self.parent.reload();
+                        }
                     }).fail(function (jqxhr) {
                         var message;
                         try {

--- a/stackdio/ui/static/stackdio/app/models/formula.js
+++ b/stackdio/ui/static/stackdio/app/models/formula.js
@@ -217,7 +217,11 @@ define([
                                 git_password: gitPassword
                             })
                         }).done(function () {
-                            self.reload();
+                            if (self.parent && typeof self.parent.reload === 'function') {
+                                self.parent.reload();
+                            } else {
+                                self.reload();
+                            }
                         }).fail(function (jqxhr) {
                             var message;
                             try {

--- a/stackdio/ui/static/stackdio/app/models/formula.js
+++ b/stackdio/ui/static/stackdio/app/models/formula.js
@@ -303,7 +303,7 @@ define([
                             var resp = JSON.parse(jqxhr.responseText);
                             message = resp.detail.join('<br>');
                             if (Object.keys(resp).indexOf('blueprints') >= 0) {
-                                message += '<br><br>Blueprints:<br>' + resp.blueprints.join(', ');
+                                message += '<br><br>Blueprints:<ul><li>' + resp.blueprints.join('</li><li>') + '</li></ul>';
                             }
                         } catch (e) {
                             message = 'Oops... there was a server error.  This has been reported ' +

--- a/stackdio/ui/static/stackdio/app/models/formula.js
+++ b/stackdio/ui/static/stackdio/app/models/formula.js
@@ -119,6 +119,10 @@ define([
         }).done(function (formula) {
             self.raw = formula;
             self._process(formula);
+        }).fail(function (jqxhr) {
+            if (jqxhr.status == 403) {
+                window.location.reload(true);
+            }
         });
     };
 

--- a/stackdio/ui/static/stackdio/app/models/group.js
+++ b/stackdio/ui/static/stackdio/app/models/group.js
@@ -207,12 +207,11 @@ define([
                         method: 'DELETE',
                         url: self.raw.url
                     }).done(function () {
-                        if (self.parent.reload) {
+                        if (window.location.pathname !== '/groups/') {
+                            window.location = '/groups/';
+                        } else if (self.parent && typeof self.parent.reload === 'function') {
                             self.parent.reload();
                         }
-
-                        // Go back to the list page
-                        window.location = '/groups/';
                     }).fail(function (jqxhr) {
                         var message;
                         if (jqxhr.status === 403) {

--- a/stackdio/ui/static/stackdio/app/models/snapshot.js
+++ b/stackdio/ui/static/stackdio/app/models/snapshot.js
@@ -135,8 +135,12 @@ define([
                     $.ajax({
                         method: 'DELETE',
                         url: self.raw.url
-                    }).done(function (snapshot) {
-                        window.location = '/snapshots/';
+                    }).done(function () {
+                        if (window.location.pathname !== '/snapshots/') {
+                            window.location = '/snapshots/';
+                        } else if (self.parent && typeof self.parent.reload === 'function') {
+                            self.parent.reload();
+                        }
                     }).fail(function (jqxhr) {
                         var message;
                         try {

--- a/stackdio/ui/static/stackdio/app/models/stack.js
+++ b/stackdio/ui/static/stackdio/app/models/stack.js
@@ -162,6 +162,10 @@ define([
         }).done(function (stack) {
             self.raw = stack;
             self._process(stack);
+        }).fail(function (jqxhr) {
+            if (jqxhr.status == 403) {
+                window.location.reload(true);
+            }
         });
     };
 
@@ -174,6 +178,10 @@ define([
         }).done(function (stack) {
             self.raw = stack;
             self._processStatus(stack.status);
+        }).fail(function (jqxhr) {
+            if (jqxhr.status == 403) {
+                window.location.reload(true);
+            }
         });
     };
 

--- a/stackdio/ui/static/stackdio/app/models/stack.js
+++ b/stackdio/ui/static/stackdio/app/models/stack.js
@@ -311,7 +311,11 @@ define([
                             action: action
                         })
                     }).done(function () {
-                        self.reload();
+                        if (self.parent && typeof self.parent.reload === 'function') {
+                            self.parent.reload();
+                        } else {
+                            self.reload();
+                        }
                     }).fail(function (jqxhr) {
                         var message;
                         try {
@@ -488,6 +492,9 @@ define([
                     }).done(function (stack) {
                         self.raw = stack;
                         self._process(stack);
+                        if (self.parent && typeof self.parent.reload === 'function') {
+                            self.parent.reload();
+                        }
                     }).fail(function (jqxhr) {
                         var message;
                         try {

--- a/stackdio/ui/static/stackdio/app/models/stack.js
+++ b/stackdio/ui/static/stackdio/app/models/stack.js
@@ -111,17 +111,10 @@ define([
                    'You can get it all back by later running the "launch" action on this stack.'
     };
 
-    Stack.prototype._process = function (raw) {
-        this.title(raw.title);
-        this.description(raw.description);
-        this.createUsers(raw.create_users);
-        this.status(raw.status);
-        this.hostCount(raw.host_count);
-        this.namespace(raw.namespace);
-        this.created(moment(raw.created));
-
+    Stack.prototype._processStatus = function (status) {
+        this.status(status);
         // Determine what type of label should be around the status
-        switch (raw.status) {
+        switch (status) {
             case 'finished':
             case 'ok':
                 this.labelClass('label-success');
@@ -150,6 +143,16 @@ define([
         }
     };
 
+    Stack.prototype._process = function (raw) {
+        this.title(raw.title);
+        this.description(raw.description);
+        this.createUsers(raw.create_users);
+        this.hostCount(raw.host_count);
+        this.namespace(raw.namespace);
+        this.created(moment(raw.created));
+        this._processStatus(raw.status);
+    };
+
     // Reload the current stack
     Stack.prototype.reload = function () {
         var self = this;
@@ -159,6 +162,18 @@ define([
         }).done(function (stack) {
             self.raw = stack;
             self._process(stack);
+        });
+    };
+
+    // Reload the current stack
+    Stack.prototype.refreshStatus = function () {
+        var self = this;
+        return $.ajax({
+            method: 'GET',
+            url: self.raw.url
+        }).done(function (stack) {
+            self.raw = stack;
+            self._processStatus(stack.status);
         });
     };
 

--- a/stackdio/ui/static/stackdio/app/utils/formula-versions.js
+++ b/stackdio/ui/static/stackdio/app/utils/formula-versions.js
@@ -1,0 +1,110 @@
+
+ /*!
+  * Copyright 2014,  Digital Reasoning
+  * 
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  * 
+  *     http://www.apache.org/licenses/LICENSE-2.0
+  * 
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  * 
+*/
+
+define([
+    'jquery',
+    'select2'
+], function($) {
+    'use strict';
+    return {
+        getAllFormulas: function (callback) {
+            // Grab the formulas
+            var fullFormulasList = [];
+
+            function getFormulas(url) {
+                $.ajax({
+                    method: 'GET',
+                    url: url
+                }).done(function (formulas) {
+                    fullFormulasList.push.apply(fullFormulasList, formulas.results);
+                    if (formulas.next === null) {
+                        callback(fullFormulasList);
+                    } else {
+                        getFormulas(formulas.next);
+                    }
+                });
+            }
+
+            getFormulas('/api/formulas/');
+        },
+        createVersionSelector: function (version, formulaList) {
+            var validVersionsUrl = null;
+
+            for (var i = 0, length = formulaList.length; i < length; ++i) {
+                if (formulaList[i].uri === version.formula()) {
+                    validVersionsUrl = formulaList[i].valid_versions;
+                    break;
+                }
+            }
+
+            if (!validVersionsUrl) {
+                console.warn('Formula ' + version.formula() + ' not found...');
+                return;
+            }
+
+            var $el = $('#' + version.formulaHtmlId());
+
+            var ver = version.version();
+
+            $el.append('<option value="' + ver + '" title="' + ver + '">' + ver + '</option>');
+
+            // Unhide it
+            $el.removeClass('hidden-formula-versions');
+
+            $el.select2({
+                ajax: {
+                    url: validVersionsUrl,
+                    dataType: 'json',
+                    delay: 100,
+                    data: function (params) {
+                        return {
+                            title: params.term
+                        };
+                    },
+                    processResults: function (data) {
+                        var results = [];
+                        data.results.forEach(function (version) {
+                            results.push({
+                                id: version,
+                                text: version,
+                                version: version
+                            });
+                        });
+                        return {
+                            results: results
+                        };
+                    },
+                    cache: true
+                },
+                theme: 'bootstrap',
+                placeholder: 'Select a version...',
+                templateResult: function (version) {
+                    return version.text;
+                },
+                minimumInputLength: 0
+            });
+
+            $el.val(ver).trigger('change');
+
+            $el.on('select2:select', function (ev) {
+                var selectedVersion = ev.params.data;
+                version.version(selectedVersion.version);
+            });
+        }
+    };
+});

--- a/stackdio/ui/static/stackdio/app/utils/formula-versions.js
+++ b/stackdio/ui/static/stackdio/app/utils/formula-versions.js
@@ -53,8 +53,8 @@ define([
             }
 
             if (!validVersionsUrl) {
-                console.warn('Formula ' + version.formula() + ' not found...');
-                return;
+                // The user probably doesn't have permission to view this formula
+                return false;
             }
 
             var $el = $('#' + version.formulaHtmlId());
@@ -105,6 +105,8 @@ define([
                 var selectedVersion = ev.params.data;
                 version.version(selectedVersion.version);
             });
+
+            return true;
         }
     };
 });

--- a/stackdio/ui/static/stackdio/app/viewmodels/blueprint-detail.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/blueprint-detail.js
@@ -36,10 +36,10 @@ define([
                 title: 'Blueprints',
                 href: '/blueprints/'
             },
-            ko.observable({
+            {
                 active: true,
                 title: window.stackdio.blueprintTitle
-            })
+            }
         ];
 
         self.subscription = null;

--- a/stackdio/ui/static/stackdio/app/viewmodels/blueprint-detail.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/blueprint-detail.js
@@ -27,11 +27,6 @@ define([
 
         // View variables
         self.blueprint = null;
-
-        // For the breadcrumb only
-        self.blueprintTitle = ko.observable('');
-
-        self.blueprintTitle = ko.observable('');
         self.blueprintUrl = ko.observable('');
 
         // Override the breadcrumbs
@@ -43,9 +38,7 @@ define([
             },
             ko.observable({
                 active: true,
-                title: ko.computed(function() {
-                    return self.blueprintTitle()
-                })
+                title: window.stackdio.blueprintTitle
             })
         ];
 
@@ -61,7 +54,6 @@ define([
             self.blueprint = new Blueprint(window.stackdio.blueprintId, self);
             self.blueprint.waiting.done(function () {
                 document.title = 'stackd.io | Blueprint Detail - ' + self.blueprint.title();
-                self.blueprintTitle(self.blueprint.title());
             }).fail(function () {
                 // Just go back to the main page if we fail
                 window.location = '/blueprints/';

--- a/stackdio/ui/static/stackdio/app/viewmodels/blueprint-formula-versions.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/blueprint-formula-versions.js
@@ -30,12 +30,12 @@ define([
             },
             {
                 active: false,
-                title: 'Blueprint Detail',
+                title: window.stackdio.blueprintTitle,
                 href: '/blueprints/' + window.stackdio.blueprintId + '/'
             },
             {
                 active: true,
-                title: 'Blueprint Formula Versions'
+                title: 'Formula Versions'
             }
         ],
         objectId: window.stackdio.blueprintId,

--- a/stackdio/ui/static/stackdio/app/viewmodels/blueprint-object-permissions.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/blueprint-object-permissions.js
@@ -34,7 +34,7 @@ define([
                 },
                 {
                     active: false,
-                    title: 'Blueprint Detail',
+                    title: window.stackdio.blueprintTitle,
                     href: this.saveUrl
                 },
                 {

--- a/stackdio/ui/static/stackdio/app/viewmodels/blueprint-properties.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/blueprint-properties.js
@@ -26,6 +26,8 @@ define([
     return function () {
         var self = this;
 
+        self.blueprint = new Blueprint(window.stackdio.blueprintId);
+
         self.breadcrumbs = [
             {
                 active: false,
@@ -34,18 +36,16 @@ define([
             },
             {
                 active: false,
-                title: 'Blueprint Detail',
+                title: window.stackdio.blueprintTitle,
                 href: '/blueprints/' + window.stackdio.blueprintId + '/'
             },
             {
                 active: true,
-                title: 'Blueprint Properties'
+                title: 'Properties'
             }
         ];
 
         self.validProperties = true;
-
-        self.blueprint = new Blueprint(window.stackdio.blueprintId);
 
         self.propertiesJSON = ko.pureComputed({
             read: function () {

--- a/stackdio/ui/static/stackdio/app/viewmodels/cloud-account-detail.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/cloud-account-detail.js
@@ -27,11 +27,6 @@ define([
 
         // View variables
         self.account = null;
-
-        // For the breadcrumb only
-        self.accountTitle = ko.observable('');
-
-        self.accountTitle = ko.observable('');
         self.accountUrl = ko.observable('');
 
         // Override the breadcrumbs
@@ -41,12 +36,10 @@ define([
                 title: 'Cloud Accounts',
                 href: '/accounts/'
             },
-            ko.observable({
+            {
                 active: true,
-                title: ko.computed(function() {
-                    return self.accountTitle()
-                })
-            })
+                title: window.stackdio.accountTitle
+            }
         ];
 
         self.subscription = null;
@@ -61,7 +54,6 @@ define([
             self.account = new CloudAccount(window.stackdio.accountId, self);
             self.account.waiting.done(function () {
                 document.title = 'stackd.io | Cloud Account Detail - ' + self.account.title();
-                self.accountTitle(self.account.title());
             }).fail(function () {
                 // Just go back to the main page if we fail
                 window.location = '/accounts/';

--- a/stackdio/ui/static/stackdio/app/viewmodels/cloud-account-images.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/cloud-account-images.js
@@ -30,12 +30,12 @@ define([
             },
             {
                 active: false,
-                title: 'Cloud Account Detail',
+                title: window.stackdio.accountTitle,
                 href: '/accounts/' + window.stackdio.accountId + '/'
             },
             {
                 active: true,
-                title: 'Cloud Account Images'
+                title: 'Images'
             }
         ],
         model: CloudImage,

--- a/stackdio/ui/static/stackdio/app/viewmodels/cloud-account-object-permissions.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/cloud-account-object-permissions.js
@@ -34,7 +34,7 @@ define([
                 },
                 {
                     active: false,
-                    title: 'Cloud Account Detail',
+                    title: window.stackdio.accountTitle,
                     href: this.saveUrl
                 },
                 {

--- a/stackdio/ui/static/stackdio/app/viewmodels/cloud-account-security-groups.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/cloud-account-security-groups.js
@@ -34,7 +34,7 @@ define([
             },
             {
                 active: false,
-                title: 'Cloud Account Detail',
+                title: window.stackdio.accountTitle,
                 href: '/accounts/' + window.stackdio.accountId + '/'
             },
             {

--- a/stackdio/ui/static/stackdio/app/viewmodels/cloud-image-detail.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/cloud-image-detail.js
@@ -31,10 +31,6 @@ define([
         self.image = null;
         self.account = null;
 
-        // For the breadcrumb only
-        self.imageTitle = ko.observable('');
-
-        self.imageTitle = ko.observable('');
         self.imageUrl = ko.observable('');
 
         self.accountTitle = ko.observable();
@@ -52,19 +48,17 @@ define([
                 },
                 {
                     active: false,
-                    title: 'Cloud Account Detail',
+                    title: window.stackdio.accountTitle,
                     href: ko.computed(function () { return '/accounts/' + self.accountId() + '/';})
                 },
                 {
                     active: false,
-                    title: 'Cloud Account Images',
+                    title: 'Images',
                     href: ko.computed(function () { return '/accounts/' + self.accountId() + '/images/';})
                 },
                 {
                     active: true,
-                    title: ko.computed(function() {
-                        return self.imageTitle()
-                    })
+                    title: window.stackdio.imageTitle
                 }
             ];
         } else {
@@ -76,9 +70,7 @@ define([
                 },
                 {
                     active: true,
-                    title: ko.computed(function() {
-                        return self.imageTitle()
-                    })
+                    title: window.stackdio.imageTitle
                 }
             ];
         }
@@ -121,7 +113,6 @@ define([
             self.account = new CloudAccount(window.stackdio.accountId, self);
             self.image.waiting.done(function () {
                 document.title = 'stackd.io | Cloud Image Detail - ' + self.image.title();
-                self.imageTitle(self.image.title());
                 self.accountId(self.image.raw.account);
 
                 // Set the default size

--- a/stackdio/ui/static/stackdio/app/viewmodels/cloud-image-object-permissions.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/cloud-image-object-permissions.js
@@ -34,7 +34,7 @@ define([
                 },
                 {
                     active: false,
-                    title: 'Cloud Image Detail',
+                    title: window.stackdio.imageTitle,
                     href: this.saveUrl
                 },
                 {

--- a/stackdio/ui/static/stackdio/app/viewmodels/formula-detail.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/formula-detail.js
@@ -26,7 +26,17 @@ define([
     'use strict';
 
     return Pagination.extend({
-        breadcrumbs: [],
+        breadcrumbs: [
+            {
+                active: false,
+                title: 'Formulas',
+                href: '/formulas/'
+            },
+            {
+                active: true,
+                title: window.stackdio.formulaTitle
+            }
+        ],
         model: Component,
         baseUrl: '/formulas/' + window.stackdio.formulaId + '/',
         initialUrl: '/api/formulas/' + window.stackdio.formulaId + '/components/',
@@ -37,29 +47,14 @@ define([
         ],
         autoRefresh: false,
         formula: null,
-        formulaTitle: ko.observable(''),
         formulaUrl: ko.observable(''),
         init: function () {
             this._super();
             var self = this;
-            this.breadcrumbs = [
-                {
-                    active: false,
-                    title: 'Formulas',
-                    href: '/formulas/'
-                },
-                ko.observable({
-                    active: true,
-                    title: ko.computed(function() {
-                        return self.formulaTitle()
-                    })
-                })
-            ];
 
             this.formula = new Formula(window.stackdio.formulaId, this);
             this.formula.waiting.done(function () {
                 document.title = 'stackd.io | Formula Detail - ' + self.formula.title();
-                self.formulaTitle(self.formula.title());
             }).fail(function () {
                 // Just go back to the main page if we fail
                 window.location = '/formulas/';

--- a/stackdio/ui/static/stackdio/app/viewmodels/formula-object-permissions.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/formula-object-permissions.js
@@ -34,7 +34,7 @@ define([
                 },
                 {
                     active: false,
-                    title: 'Formula Detail',
+                    title: window.stackdio.formulaTitle,
                     href: this.saveUrl
                 },
                 {

--- a/stackdio/ui/static/stackdio/app/viewmodels/formula-properties.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/formula-properties.js
@@ -34,12 +34,12 @@ define([
             },
             {
                 active: false,
-                title: 'Formula Detail',
+                title: window.stackdio.formulaTitle,
                 href: '/formulas/' + window.stackdio.formulaId + '/'
             },
             {
                 active: true,
-                title: 'Formula Properties'
+                title: 'Default Properties'
             }
         ];
 

--- a/stackdio/ui/static/stackdio/app/viewmodels/group-object-permissions.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/group-object-permissions.js
@@ -34,7 +34,7 @@ define([
                 },
                 {
                     active: false,
-                    title: 'Group Detail',
+                    title: window.stackdio.groupName,
                     href: this.saveUrl
                 },
                 {

--- a/stackdio/ui/static/stackdio/app/viewmodels/snapshot-detail.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/snapshot-detail.js
@@ -27,11 +27,6 @@ define([
 
         // View variables
         self.snapshot = null;
-
-        // For the breadcrumb only
-        self.snapshotTitle = ko.observable('');
-
-        self.snapshotTitle = ko.observable('');
         self.snapshotUrl = ko.observable('');
 
         // Override the breadcrumbs
@@ -41,12 +36,10 @@ define([
                 title: 'Snapshots',
                 href: '/snapshots/'
             },
-            ko.observable({
+            {
                 active: true,
-                title: ko.computed(function() {
-                    return self.snapshotTitle()
-                })
-            })
+                title: window.stackdio.snapshotTitle
+            }
         ];
 
         self.reset = function() {
@@ -54,7 +47,6 @@ define([
             self.snapshot = new Snapshot(window.stackdio.snapshotId, self);
             self.snapshot.waiting.done(function () {
                 document.title = 'stackd.io | Snapshot Detail - ' + self.snapshot.title();
-                self.snapshotTitle(self.snapshot.title());
             }).fail(function () {
                 // Just go back to the main page if we fail
                 window.location = '/snapshots/';

--- a/stackdio/ui/static/stackdio/app/viewmodels/snapshot-object-permissions.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/snapshot-object-permissions.js
@@ -34,7 +34,7 @@ define([
                 },
                 {
                     active: false,
-                    title: 'Snapshot Detail',
+                    title: window.stackdio.snapshotTitle,
                     href: this.saveUrl
                 },
                 {

--- a/stackdio/ui/static/stackdio/app/viewmodels/stack-access-rules.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/stack-access-rules.js
@@ -34,12 +34,12 @@ define([
             },
             {
                 active: false,
-                title: 'Stack Detail',
+                title: window.stackdio.stackTitle,
                 href: '/stacks/' + window.stackdio.stackId + '/'
             },
             {
                 active: true,
-                title: 'Stack Access Rules'
+                title: 'Access Rules'
             }
         ],
         stack: ko.observable(),

--- a/stackdio/ui/static/stackdio/app/viewmodels/stack-commands.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/stack-commands.js
@@ -34,12 +34,12 @@ define([
             },
             {
                 active: false,
-                title: 'Stack Detail',
+                title: window.stackdio.stackTitle,
                 href: '/stacks/' + window.stackdio.stackId + '/'
             },
             {
                 active: true,
-                title: 'Stack Commands'
+                title: 'Commands'
             }
         ],
         stack: ko.observable(),

--- a/stackdio/ui/static/stackdio/app/viewmodels/stack-create.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/stack-create.js
@@ -22,6 +22,7 @@ define([
     'bootbox',
     'utils/formula-versions',
     'models/formula-version',
+    'fuelux',
     'select2'
 ], function ($, ko, Ladda, bootbox, versionUtils, FormulaVersion) {
     'use strict';
@@ -130,6 +131,7 @@ define([
         self.properties = ko.observable({});
         self.formulaVersions = ko.observableArray([]);
         self.formulas = null;
+        self.versionsReady = ko.observable();
 
         self.validProperties = true;
         self.createButton = null;
@@ -173,6 +175,7 @@ define([
             self.namespace('');
             self.properties({});
             self.formulaVersions([]);
+            self.versionsReady(false);
         };
 
         self.createSelectors = function () {
@@ -188,6 +191,8 @@ define([
             markForRemoval.forEach(function (version) {
                 self.formulaVersions.remove(version);
             });
+
+            self.versionsReady(true);
         };
 
         self.removeErrors = function(keys) {

--- a/stackdio/ui/static/stackdio/app/viewmodels/stack-create.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/stack-create.js
@@ -176,8 +176,17 @@ define([
         };
 
         self.createSelectors = function () {
+            var markForRemoval = [];
             self.formulaVersions().forEach(function (version) {
-                versionUtils.createVersionSelector(version, self.formulas);
+                if (!versionUtils.createVersionSelector(version, self.formulas)) {
+                    // We don't have permission, add it to the removal list
+                    markForRemoval.push(version);
+                }
+            });
+
+            // Get rid of ones we don't have permission to see
+            markForRemoval.forEach(function (version) {
+                self.formulaVersions.remove(version);
             });
         };
 

--- a/stackdio/ui/static/stackdio/app/viewmodels/stack-create.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/stack-create.js
@@ -49,7 +49,7 @@ define([
                 delay: 100,
                 data: function (params) {
                     return {
-                        title: params.term
+                        q: params.term
                     };
                 },
                 processResults: function (data) {

--- a/stackdio/ui/static/stackdio/app/viewmodels/stack-detail.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/stack-detail.js
@@ -27,12 +27,8 @@ define([
 
         // View variables
         self.stack = null;
-
-        // For the breadcrumb only
-        self.stackTitle = ko.observable('');
-
-        self.blueprintTitle = ko.observable('');
-        self.blueprintUrl = ko.observable('');
+        self.blueprintTitle = ko.observable(window.stackdio.blueprintTitle);
+        self.blueprintUrl = ko.observable('/blueprints/' + window.stackdio.blueprintId + '/');
 
         // Override the breadcrumbs
         self.breadcrumbs = [
@@ -41,12 +37,10 @@ define([
                 title: 'Stacks',
                 href: '/stacks/'
             },
-            ko.observable({
+            {
                 active: true,
-                title: ko.computed(function() {
-                    return self.stackTitle()
-                })
-            })
+                title: window.stackdio.stackTitle
+            }
         ];
 
         self.subscription = null;
@@ -61,11 +55,6 @@ define([
             self.stack = new Stack(window.stackdio.stackId, self);
             self.stack.waiting.done(function () {
                 document.title = 'stackd.io | Stack Detail - ' + self.stack.title();
-                self.stackTitle(self.stack.title());
-                self.stack.loadBlueprint().done(function () {
-                    self.blueprintTitle(self.stack.blueprint().title() + '  --  ' + self.stack.blueprint().description());
-                    self.blueprintUrl('/blueprints/' + self.stack.blueprint().id + '/');
-                });
             }).fail(function () {
                 // Just go back to the main page if we fail
                 window.location = '/stacks/';

--- a/stackdio/ui/static/stackdio/app/viewmodels/stack-detail.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/stack-detail.js
@@ -82,9 +82,10 @@ define([
 
         // Functions
         self.refreshStack = function () {
-            self.stack.loadHistory().fail(function () {
+            self.stack.reload().fail(function () {
                 window.location = '/stacks/';
             });
+            self.stack.loadHistory();
         };
 
         // React to an open-dropdown event & lazy load the actions

--- a/stackdio/ui/static/stackdio/app/viewmodels/stack-detail.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/stack-detail.js
@@ -71,7 +71,7 @@ define([
 
         // Functions
         self.refreshStack = function () {
-            self.stack.reload().fail(function () {
+            self.stack.refreshStatus().fail(function () {
                 window.location = '/stacks/';
             });
             self.stack.loadHistory();

--- a/stackdio/ui/static/stackdio/app/viewmodels/stack-formula-versions.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/stack-formula-versions.js
@@ -30,12 +30,12 @@ define([
             },
             {
                 active: false,
-                title: 'Stack Detail',
+                title: window.stackdio.stackTitle,
                 href: '/stacks/' + window.stackdio.stackId + '/'
             },
             {
                 active: true,
-                title: 'Stack Formula Versions'
+                title: 'Formula Versions'
             }
         ],
         objectId: window.stackdio.stackId,

--- a/stackdio/ui/static/stackdio/app/viewmodels/stack-hosts.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/stack-hosts.js
@@ -34,12 +34,12 @@ define([
             },
             {
                 active: false,
-                title: 'Stack Detail',
+                title: window.stackdio.stackTitle,
                 href: '/stacks/' + window.stackdio.stackId + '/'
             },
             {
                 active: true,
-                title: 'Stack Hosts'
+                title: 'Hosts'
             }
         ],
         stack: ko.observable(),

--- a/stackdio/ui/static/stackdio/app/viewmodels/stack-labels.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/stack-labels.js
@@ -35,12 +35,12 @@ define([
             },
             {
                 active: false,
-                title: 'Stack Detail',
+                title: window.stackdio.stackTitle,
                 href: '/stacks/' + window.stackdio.stackId + '/'
             },
             {
                 active: true,
-                title: 'Stack Labels'
+                title: 'Labels'
             }
         ],
         stack: ko.observable(),

--- a/stackdio/ui/static/stackdio/app/viewmodels/stack-logs.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/stack-logs.js
@@ -77,7 +77,11 @@ define([
                         logDiv.scrollTop = logDiv.scrollHeight - 498;
                     }
                 }).fail(function (jqxhr) {
-                    utils.growlAlert('Failed to load log', 'danger');
+                    if (jqxhr.status == 403) {
+                        window.location.reload(true);
+                    } else {
+                        utils.growlAlert('Failed to load log', 'danger');
+                    }
                 });
             }
         };

--- a/stackdio/ui/static/stackdio/app/viewmodels/stack-logs.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/stack-logs.js
@@ -35,12 +35,12 @@ define([
             },
             {
                 active: false,
-                title: 'Stack Detail',
+                title: window.stackdio.stackTitle,
                 href: '/stacks/' + window.stackdio.stackId + '/'
             },
             {
                 active: true,
-                title: 'Stack Logs'
+                title: 'Logs'
             }
         ];
 

--- a/stackdio/ui/static/stackdio/app/viewmodels/stack-logs.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/stack-logs.js
@@ -20,7 +20,8 @@ define([
     'knockout',
     'bootbox',
     'utils/utils',
-    'models/stack'
+    'models/stack',
+    'fuelux'
 ], function ($, ko, bootbox, utils, Stack) {
     'use strict';
 

--- a/stackdio/ui/static/stackdio/app/viewmodels/stack-object-permissions.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/stack-object-permissions.js
@@ -34,7 +34,7 @@ define([
                 },
                 {
                     active: false,
-                    title: 'Stack Detail',
+                    title: window.stackdio.stackTitle,
                     href: this.saveUrl
                 },
                 {

--- a/stackdio/ui/static/stackdio/app/viewmodels/stack-properties.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/stack-properties.js
@@ -34,12 +34,12 @@ define([
             },
             {
                 active: false,
-                title: 'Stack Detail',
+                title: window.stackdio.stackTitle,
                 href: '/stacks/' + window.stackdio.stackId + '/'
             },
             {
                 active: true,
-                title: 'Stack Properties'
+                title: 'Properties'
             }
         ];
 

--- a/stackdio/ui/static/stackdio/app/viewmodels/stack-volumes.js
+++ b/stackdio/ui/static/stackdio/app/viewmodels/stack-volumes.js
@@ -34,12 +34,12 @@ define([
             },
             {
                 active: false,
-                title: 'Stack Detail',
+                title: window.stackdio.stackTitle,
                 href: '/stacks/' + window.stackdio.stackId + '/'
             },
             {
                 active: true,
-                title: 'Stack Volumes'
+                title: 'Volumes'
             }
         ],
         autoRefresh: false,

--- a/stackdio/ui/static/stackdio/css/stackdio.css
+++ b/stackdio/ui/static/stackdio/css/stackdio.css
@@ -99,6 +99,11 @@ Bootstrap overrides
     padding-bottom: 10px;
 }
 
+.modal-body {
+    max-height: calc(100vh - 212px);
+    overflow-y: auto;
+}
+
 #main-content {
     position: relative;
 }

--- a/stackdio/ui/templates/blueprints/blueprint-detail-base.html
+++ b/stackdio/ui/templates/blueprints/blueprint-detail-base.html
@@ -8,7 +8,8 @@
     {{ block.super }}
     <script type="text/javascript">
         if (typeof window.stackdio == 'undefined') window.stackdio = {};
-        window.stackdio.blueprintId = {{ blueprint_id }};
+        window.stackdio.blueprintId = {{ blueprint.id }};
+        window.stackdio.blueprintTitle = '{{ blueprint.title }}';
     </script>
 {% endblock %}
 
@@ -18,10 +19,10 @@
         <div class="col-sm-3 col-sm-push-9">
             <ul class="nav nav-pills nav-stacked">
                 <li role="presentation"{% if page_id == 'detail' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:blueprint-detail' pk=blueprint_id %}">Detail</a>
+                    <a href="{% url 'ui:blueprint-detail' pk=blueprint.id %}">Detail</a>
                 </li>
                 <li role="presentation"{% if page_id == 'properties' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:blueprint-properties' pk=blueprint_id %}">Properties</a>
+                    <a href="{% url 'ui:blueprint-properties' pk=blueprint.id %}">Properties</a>
                 </li>
 {#                <li role="presentation"{% if page_id == 'host_definitions' %} class="active"{% endif %}>#}
 {#                    <a href="">Host Definitions</a>#}
@@ -30,11 +31,11 @@
 {#                    <a href="">Access Rules</a>#}
 {#                </li>#}
                 <li role="presentation"{% if page_id == 'formula-versions' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:blueprint-formula-versions' pk=blueprint_id %}">Formula Versions</a>
+                    <a href="{% url 'ui:blueprint-formula-versions' pk=blueprint.id %}">Formula Versions</a>
                 </li>
                 {% if has_admin %}
                 <li role="presentation"{% if page_id == 'permissions' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:blueprint-object-permissions' pk=blueprint_id %}">Permissions</a>
+                    <a href="{% url 'ui:blueprint-object-permissions' pk=blueprint.id %}">Permissions</a>
                 </li>
                 {% endif %}
             </ul>

--- a/stackdio/ui/templates/blueprints/blueprint-detail.html
+++ b/stackdio/ui/templates/blueprints/blueprint-detail.html
@@ -26,12 +26,16 @@
                     </div>
                 </div>
                 <div class="form-group" style="margin-top: 15px">
+                    {% if has_update %}
                     <button type="submit" class="btn btn-primary">Save</button>
+                    {% endif %}
 
+                    {% if has_delete %}
                     <button class="btn btn-danger" data-bind="click: function () { blueprint.delete() }">
                         Delete
                         <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                     </button>
+                    {% endif %}
                 </div>
             </form>
         </div>

--- a/stackdio/ui/templates/blueprints/blueprint-formula-versions.html
+++ b/stackdio/ui/templates/blueprints/blueprint-formula-versions.html
@@ -23,9 +23,13 @@
                     <!-- ko foreach: sortedObjects -->
                     <tr class="stackdio-hidden-on-load" data-bind="visible: $root.versionsReady">
                         <td data-bind="text: formula"></td>
+                        {% if has_update %}
                         <td>
                             <select style="width: 100%" class="hidden-formula-versions" data-bind="attr: {id: formulaHtmlId}"></select>
                         </td>
+                        {% else %}
+                        <td data-bind="text: version"></td>
+                        {% endif %}
                     </tr>
                     <!-- /ko -->
                     </tbody>
@@ -33,10 +37,12 @@
             </div>
         </div>
 
+        {% if has_update %}
         <div class="row">
             <div class="col-md-12">
                 <button type="submit" class="btn btn-primary" data-bind="click: function () { saveVersions() }">Save</button>
             </div>
         </div>
+        {% endif %}
     </div>
 {% endblock %}

--- a/stackdio/ui/templates/blueprints/blueprint-formula-versions.html
+++ b/stackdio/ui/templates/blueprints/blueprint-formula-versions.html
@@ -21,7 +21,7 @@
                     </thead>
                     <tbody>
                     <!-- ko foreach: sortedObjects -->
-                    <tr class="stackdio-hidden-on-load">
+                    <tr class="stackdio-hidden-on-load" data-bind="visible: $root.versionsReady">
                         <td data-bind="text: formula"></td>
                         <td>
                             <select style="width: 100%" class="hidden-formula-versions" data-bind="attr: {id: formulaHtmlId}"></select>

--- a/stackdio/ui/templates/blueprints/blueprint-list.html
+++ b/stackdio/ui/templates/blueprints/blueprint-list.html
@@ -43,7 +43,7 @@
                     <td data-bind="text: title, click: function (blueprint) { $root.goToDetailPage(blueprint) }"></td>
                     <td data-bind="text: description, click: function (blueprint) { $root.goToDetailPage(blueprint) }"></td>
                     <td class="text-center">
-                        <a href="#" data-bind="click: $data.delete">
+                        <a href="#" data-bind="click: $data.delete, if: $root.permissionsMap[$data.id].delete">
                             <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                         </a>
                     </td>

--- a/stackdio/ui/templates/blueprints/blueprint-properties.html
+++ b/stackdio/ui/templates/blueprints/blueprint-properties.html
@@ -10,11 +10,17 @@
                 <div class="form-group" id="properties">
                     <label for="blueprintProperties">Properties</label>
 
+                    {% if has_update %}
                     <textarea class="form-control" id="blueprintProperties" rows="25"
                               data-bind="value: propertiesJSON, valueUpdate: 'keyup'"></textarea>
+                    {% else %}
+                    <pre data-bind="text: propertiesJSON"></pre>
+                    {% endif %}
                 </div>
 
+                {% if has_update %}
                 <button type="submit" class="btn btn-success">Save</button>
+                {% endif %}
             </form>
         </div>
     </div>

--- a/stackdio/ui/templates/cloud/cloud-account-detail-base.html
+++ b/stackdio/ui/templates/cloud/cloud-account-detail-base.html
@@ -8,7 +8,8 @@
     {{ block.super }}
     <script type="text/javascript">
         if (typeof window.stackdio == 'undefined') window.stackdio = {};
-        window.stackdio.accountId = {{ account_id }};
+        window.stackdio.accountId = {{ account.id }};
+        window.stackdio.accountTitle = '{{ account.title }}';
     </script>
 {% endblock %}
 
@@ -18,23 +19,23 @@
         <div class="col-sm-3 col-sm-push-9">
             <ul class="nav nav-pills nav-stacked">
                 <li role="presentation"{% if page_id == 'detail' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:cloud-account-detail' pk=account_id %}">Detail</a>
+                    <a href="{% url 'ui:cloud-account-detail' pk=account.id %}">Detail</a>
                 </li>
                 <li role="presentation"{% if page_id == 'images' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:cloud-account-images' pk=account_id %}">Images</a>
+                    <a href="{% url 'ui:cloud-account-images' pk=account.id %}">Images</a>
                 </li>
                 <li role="presentation"{% if page_id == 'security-groups' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:cloud-account-security-groups' pk=account_id %}">Security Groups</a>
+                    <a href="{% url 'ui:cloud-account-security-groups' pk=account.id %}">Security Groups</a>
                 </li>
 {#                <li role="presentation"{% if page_id == 'global-orchestration' %} class="active"{% endif %}>#}
 {#                    <a href="">Global Orchestration</a>#}
 {#                </li>#}
 {#                <li role="presentation"{% if page_id == 'formula-versions' %} class="active"{% endif %}>#}
-{#                    <a href="{% url 'ui:cloud-account-formula-versions' pk=account_id %}">Formula Versions</a>#}
+{#                    <a href="{% url 'ui:cloud-account-formula-versions' pk=account.id %}">Formula Versions</a>#}
 {#                </li>#}
                 {% if has_admin %}
                 <li role="presentation"{% if page_id == 'permissions' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:cloud-account-object-permissions' pk=account_id %}">Permissions</a>
+                    <a href="{% url 'ui:cloud-account-object-permissions' pk=account.id %}">Permissions</a>
                 </li>
                 {% endif %}
             </ul>

--- a/stackdio/ui/templates/cloud/cloud-account-detail.html
+++ b/stackdio/ui/templates/cloud/cloud-account-detail.html
@@ -32,12 +32,16 @@
                     </div>
                 </div>
                 <div class="form-group" style="margin-top: 15px">
+                    {% if has_update %}
                     <button type="submit" class="btn btn-primary">Save</button>
+                    {% endif %}
 
+                    {% if has_delete %}
                     <button class="btn btn-danger" data-bind="click: function () { account.delete() }">
                         Delete
                         <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                     </button>
+                    {% endif %}
                 </div>
             </form>
         </div>

--- a/stackdio/ui/templates/cloud/cloud-account-list.html
+++ b/stackdio/ui/templates/cloud/cloud-account-list.html
@@ -48,7 +48,7 @@
                         <i class="fa fa-lg fa-times text-danger" data-bind="visible: !createSecurityGroups()"></i>
                     </td>
                     <td class="text-center">
-                        <a href="#" data-bind="click: $data.delete">
+                        <a href="#" data-bind="click: $data.delete, if: $root.permissionsMap[$data.id].delete">
                             <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                         </a>
                     </td>

--- a/stackdio/ui/templates/cloud/cloud-image-detail-base.html
+++ b/stackdio/ui/templates/cloud/cloud-image-detail-base.html
@@ -8,7 +8,8 @@
     {{ block.super }}
     <script type="text/javascript">
         if (typeof window.stackdio == 'undefined') window.stackdio = {};
-        window.stackdio.imageId = {{ image_id }};
+        window.stackdio.imageId = {{ image.id }};
+        window.stackdio.imageTitle = '{{ image.title }}';
     </script>
 {% endblock %}
 
@@ -18,11 +19,11 @@
         <div class="col-sm-3 col-sm-push-9">
             <ul class="nav nav-pills nav-stacked">
                 <li role="presentation"{% if page_id == 'detail' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:cloud-image-detail' pk=image_id %}">Detail</a>
+                    <a href="{% url 'ui:cloud-image-detail' pk=image.id %}">Detail</a>
                 </li>
                 {% if has_admin %}
                 <li role="presentation"{% if page_id == 'permissions' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:cloud-image-object-permissions' pk=image_id %}">Permissions</a>
+                    <a href="{% url 'ui:cloud-image-object-permissions' pk=image.id %}">Permissions</a>
                 </li>
                 {% endif %}
             </ul>

--- a/stackdio/ui/templates/cloud/cloud-image-detail.html
+++ b/stackdio/ui/templates/cloud/cloud-image-detail.html
@@ -44,12 +44,16 @@
                 </div>
 
                 <div class="form-group" style="margin-top: 15px">
+                    {% if has_update %}
                     <button type="submit" class="btn btn-primary">Save</button>
+                    {% endif %}
 
+                    {% if has_delete %}
                     <button class="btn btn-danger" data-bind="click: function () { image.delete() }">
                         Delete
                         <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                     </button>
+                    {% endif %}
                 </div>
             </div>
             <div class="col-md-6">

--- a/stackdio/ui/templates/cloud/cloud-image-detail.html
+++ b/stackdio/ui/templates/cloud/cloud-image-detail.html
@@ -5,8 +5,9 @@
     {{ block.super }}
     <script type="text/javascript">
         if (typeof window.stackdio == 'undefined') window.stackdio = {};
-        window.stackdio.accountId = {{ account_id }};
-        window.stackdio.providerName = '{{ provider_name }}';
+        window.stackdio.accountId = {{ image.account.id }};
+        window.stackdio.accountTitle = '{{ image.account.title }}';
+        window.stackdio.providerName = '{{ image.account.provider.name }}';
     </script>
 {% endblock %}
 

--- a/stackdio/ui/templates/cloud/cloud-image-list.html
+++ b/stackdio/ui/templates/cloud/cloud-image-list.html
@@ -44,7 +44,7 @@
                     <td data-bind="text: description, click: function (image) { $root.goToDetailPage(image) }"></td>
                     <td data-bind="text: imageId, click: function (image) { $root.goToDetailPage(image) }">
                     <td class="text-center">
-                        <a href="#" data-bind="click: $data.delete">
+                        <a href="#" data-bind="click: $data.delete, if: $root.permissionsMap[$data.id].delete">
                             <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                         </a>
                     </td>

--- a/stackdio/ui/templates/formulas/formula-detail-base.html
+++ b/stackdio/ui/templates/formulas/formula-detail-base.html
@@ -8,7 +8,8 @@
     {{ block.super }}
     <script type="text/javascript">
         if (typeof window.stackdio == 'undefined') window.stackdio = {};
-        window.stackdio.formulaId = {{ formula_id }};
+        window.stackdio.formulaId = {{ formula.id }};
+        window.stackdio.formulaTitle = '{{ formula.title }} ({{ formula.uri }})';
     </script>
 {% endblock %}
 
@@ -18,14 +19,14 @@
         <div class="col-sm-3 col-sm-push-9">
             <ul class="nav nav-pills nav-stacked">
                 <li role="presentation"{% if page_id == 'detail' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:formula-detail' pk=formula_id %}">Components</a>
+                    <a href="{% url 'ui:formula-detail' pk=formula.id %}">Components</a>
                 </li>
                 <li role="presentation"{% if page_id == 'properties' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:formula-properties' pk=formula_id %}">Default Properties</a>
+                    <a href="{% url 'ui:formula-properties' pk=formula.id %}">Default Properties</a>
                 </li>
                 {% if has_admin %}
                 <li role="presentation"{% if page_id == 'permissions' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:formula-object-permissions' pk=formula_id %}">Permissions</a>
+                    <a href="{% url 'ui:formula-object-permissions' pk=formula.id %}">Permissions</a>
                 </li>
                 {% endif %}
             </ul>

--- a/stackdio/ui/templates/formulas/formula-detail.html
+++ b/stackdio/ui/templates/formulas/formula-detail.html
@@ -48,7 +48,9 @@
                 </div>
             </div>
             <div class="col-sm-2">
+                {% if has_update %}
                 <button type="submit" class="btn btn-success">Save</button>
+                {% endif %}
             </div>
         </form>
     </div>
@@ -64,6 +66,7 @@
             <select id="formulaVersion" style="width: 100%" class="stackdio-hidden-on-load"></select>
         </div>
         <div class="col-md-6 text-right">
+            {% if has_update %}
             <div class="btn-group action-dropdown">
                 <button type="button" class="btn btn-info dropdown-toggle"
                         data-toggle="dropdown" aria-haspopup="true"
@@ -78,6 +81,7 @@
                     </li>
                 </ul>
             </div>
+            {% endif %}
         </div>
     </div>
 

--- a/stackdio/ui/templates/formulas/formula-list.html
+++ b/stackdio/ui/templates/formulas/formula-list.html
@@ -52,7 +52,8 @@
                     </td>
                     <td>
                         <div class="btn-group btn-group-xs action-dropdown"
-                             data-bind="css: {open: $root.openActionFormulaId === id}, attr: {id: id}">
+                             data-bind="css: {open: $root.openActionFormulaId === id},
+                                        attr: {id: id}, if: $root.permissionsMap[$data.id].update">
                             <button type="button" class="btn btn-xs btn-info dropdown-toggle"
                                     data-toggle="dropdown" aria-haspopup="true"
                                     aria-expanded="false">
@@ -68,7 +69,7 @@
                         </div>
                     </td>
                     <td class="text-center">
-                        <a href="#" data-bind="click: $data.delete">
+                        <a href="#" data-bind="click: $data.delete, if: $root.permissionsMap[$data.id].delete">
                             <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                         </a>
                     </td>

--- a/stackdio/ui/templates/snapshots/snapshot-detail-base.html
+++ b/stackdio/ui/templates/snapshots/snapshot-detail-base.html
@@ -8,7 +8,8 @@
     {{ block.super }}
     <script type="text/javascript">
         if (typeof window.stackdio == 'undefined') window.stackdio = {};
-        window.stackdio.snapshotId = {{ snapshot_id }};
+        window.stackdio.snapshotId = {{ snapshot.id }};
+        window.stackdio.snapshotTitle = '{{ snapshot.title }}';
     </script>
 {% endblock %}
 
@@ -18,11 +19,11 @@
         <div class="col-sm-3 col-sm-push-9">
             <ul class="nav nav-pills nav-stacked">
                 <li role="presentation"{% if page_id == 'detail' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:snapshot-detail' pk=snapshot_id %}">Detail</a>
+                    <a href="{% url 'ui:snapshot-detail' pk=snapshot.id %}">Detail</a>
                 </li>
                 {% if has_admin %}
                 <li role="presentation"{% if page_id == 'permissions' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:snapshot-object-permissions' pk=snapshot_id %}">Permissions</a>
+                    <a href="{% url 'ui:snapshot-object-permissions' pk=snapshot.id %}">Permissions</a>
                 </li>
                 {% endif %}
             </ul>

--- a/stackdio/ui/templates/snapshots/snapshot-detail.html
+++ b/stackdio/ui/templates/snapshots/snapshot-detail.html
@@ -36,12 +36,16 @@
                            data-bind="value: snapshot.filesystemType, valueUpdate: 'keyup'">
                 </div>
                 <div class="form-group" style="margin-top: 15px">
+                    {% if has_update %}
                     <button type="submit" class="btn btn-primary">Save</button>
+                    {% endif %}
 
+                    {% if has_delete %}
                     <button class="btn btn-danger" data-bind="click: function () { snapshot.delete() }">
                         Delete
                         <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                     </button>
+                    {% endif %}
                 </div>
             </form>
         </div>

--- a/stackdio/ui/templates/snapshots/snapshot-list.html
+++ b/stackdio/ui/templates/snapshots/snapshot-list.html
@@ -48,7 +48,7 @@
                     </td>
                     <td data-bind="text: filesystemType, click: function (snapshot) { $root.goToDetailPage(snapshot) }"></td>
                     <td class="text-center">
-                        <a href="#" data-bind="click: $data.delete">
+                        <a href="#" data-bind="click: $data.delete, if: $root.permissionsMap[$data.id].delete">
                             <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                         </a>
                     </td>

--- a/stackdio/ui/templates/stackdio/js/main.js
+++ b/stackdio/ui/templates/stackdio/js/main.js
@@ -18,22 +18,24 @@
 {% load staticfiles %}
 {# Templatize this file so that the static files always work even if the static url changes #}
 
+{% with '../lib/bower_components' as bower_path %}
+
 requirejs.config({
     baseUrl: '{% static 'stackdio/app' %}',
     paths: {
-        'bloodhound': '../lib/bower_components/typeahead.js/dist/bloodhound',
-        'bootbox': '../lib/bower_components/bootbox.js/bootbox',
-        'bootstrap': '../lib/bower_components/bootstrap/dist/js/bootstrap',
-        'domReady': '../lib/bower_components/requirejs-domReady/domReady',
-        'fuelux': '../lib/bower_components/fuelux/dist/js/fuelux',
-        'jquery': '../lib/bower_components/jquery/jquery',
-        'knockout': '../lib/bower_components/knockout/dist/knockout',
-        'ladda': '../lib/bower_components/ladda/js/ladda',
-        'moment': '../lib/bower_components/moment/moment',
-        'select2': '../lib/bower_components/select2/dist/js/select2',
-        'spin': '../lib/bower_components/ladda/js/spin',
-        'typeahead': '../lib/bower_components/typeahead.js/dist/typeahead.jquery',
-        'underscore': '../lib/bower_components/underscore/underscore'
+        'bloodhound': '{{ bower_path }}/typeahead.js/dist/bloodhound',
+        'bootbox': '{{ bower_path }}/bootbox.js/bootbox',
+        'bootstrap': '{{ bower_path }}/bootstrap/dist/js/bootstrap',
+        'domReady': '{{ bower_path }}/requirejs-domReady/domReady',
+        'fuelux': '{{ bower_path }}/fuelux/dist/js/fuelux',
+        'jquery': '{{ bower_path }}/jquery/jquery',
+        'knockout': '{{ bower_path }}/knockout/dist/knockout',
+        'ladda': '{{ bower_path }}/ladda/js/ladda',
+        'moment': '{{ bower_path }}/moment/moment',
+        'select2': '{{ bower_path }}/select2/dist/js/select2',
+        'spin': '{{ bower_path }}/ladda/js/spin',
+        'typeahead': '{{ bower_path }}/typeahead.js/dist/typeahead.jquery',
+        'underscore': '{{ bower_path }}/underscore/underscore'
     },
     shim: {
         bootstrap: {
@@ -57,6 +59,8 @@ requirejs.config({
         }
     }
 });
+
+{% endwith %}
 
 // Add our custom capitalize method
 String.prototype.capitalize = function() {

--- a/stackdio/ui/templates/stackdio/page.html
+++ b/stackdio/ui/templates/stackdio/page.html
@@ -18,6 +18,14 @@
     <script type="text/javascript">
         if (typeof window.stackdio == 'undefined') window.stackdio = {};
         window.stackdio.advancedView = {{ user.settings.advanced_view | lower }};
+
+        window.stackdio.permissionsMap = {};
+        {% for obj in object_list %}
+        window.stackdio.permissionsMap['{{ obj.id }}'] = {
+            'delete': {{ obj.can_delete | lower }},
+            'update': {{ obj.can_update | lower }}
+        };
+        {% endfor %}
     </script>
 {% endblock %}
 

--- a/stackdio/ui/templates/stackdio/page.html
+++ b/stackdio/ui/templates/stackdio/page.html
@@ -19,6 +19,7 @@
         if (typeof window.stackdio == 'undefined') window.stackdio = {};
         window.stackdio.advancedView = {{ user.settings.advanced_view | lower }};
 
+        // Throw these in here so we don't have to retrieve them via AJAX
         window.stackdio.permissionsMap = {};
         {% for obj in object_list %}
         window.stackdio.permissionsMap['{{ obj.id }}'] = {

--- a/stackdio/ui/templates/stacks/stack-commands.html
+++ b/stackdio/ui/templates/stacks/stack-commands.html
@@ -2,6 +2,7 @@
 
 {% block detail-content %}
 <div class="col-sm-9 col-sm-pull-3">
+    {% if has_update %}
     <form class="form-inline" data-bind="submit: function () { runCommand() }">
         <div class="row" style="margin-top: 15px">
             <div class="form-group col-sm-3">
@@ -21,6 +22,7 @@
             </div>
         </div>
     </form>
+    {% endif %}
 
     {% include 'stackdio/stubs/pager.html' with object_type='commands' search=False %}
 

--- a/stackdio/ui/templates/stacks/stack-create.html
+++ b/stackdio/ui/templates/stacks/stack-create.html
@@ -52,11 +52,14 @@
             <div class="col-sm-6">
                 <h3>Formula Versions</h3>
                 <hr>
-                <div id="formula_versions" data-bind="foreach: formulaVersions">
+                <div id="formula_versions" data-bind="foreach: formulaVersions, visible: versionsReady">
                     <div class="form-group stackdio-hidden-on-load">
                         <label data-bind="text: formula, attr: {for: formulaHtmlId}"></label>
                         <select class="hidden-formula-versions" style="width: 100%" data-bind="attr: {id: formulaHtmlId}"></select>
                     </div>
+                </div>
+                <div class="stackdio-hidden-on-load" data-bind="visible: versionsReady() && formulaVersions().length === 0">
+                    <h5>No formula versions to set.</h5>
                 </div>
                 <p data-bind="visible: !blueprintId()">Please select a blueprint</p>
                 <button type="submit" id="create-button" data-style="slide-left"

--- a/stackdio/ui/templates/stacks/stack-create.html
+++ b/stackdio/ui/templates/stacks/stack-create.html
@@ -53,9 +53,9 @@
                 <h3>Formula Versions</h3>
                 <hr>
                 <div id="formula_versions" data-bind="foreach: formulaVersions">
-                    <div class="form-group">
-                        <label data-bind="text: formula"></label>
-                        <input type="text" class="form-control" data-bind="value: version, valueUpdate: 'keyup'">
+                    <div class="form-group stackdio-hidden-on-load">
+                        <label data-bind="text: formula, attr: {for: formulaHtmlId}"></label>
+                        <select class="hidden-formula-versions" style="width: 100%" data-bind="attr: {id: formulaHtmlId}"></select>
                     </div>
                 </div>
                 <p data-bind="visible: !blueprintId()">Please select a blueprint</p>

--- a/stackdio/ui/templates/stacks/stack-detail-base.html
+++ b/stackdio/ui/templates/stacks/stack-detail-base.html
@@ -8,7 +8,10 @@
     {{ block.super }}
     <script type="text/javascript">
         if (typeof window.stackdio == 'undefined') window.stackdio = {};
-        window.stackdio.stackId = {{ stack_id }};
+        window.stackdio.stackId = {{ stack.id }};
+        window.stackdio.stackTitle = '{{ stack.title }}';
+        window.stackdio.blueprintId = {{ stack.blueprint.id }};
+        window.stackdio.blueprintTitle = '{{ stack.blueprint.title }}  --  {{ stack.blueprint.description }}';
     </script>
 {% endblock %}
 
@@ -18,36 +21,36 @@
         <div class="col-sm-3 col-sm-push-9">
             <ul class="nav nav-pills nav-stacked">
                 <li role="presentation"{% if page_id == 'detail' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:stack-detail' pk=stack_id %}">Detail</a>
+                    <a href="{% url 'ui:stack-detail' pk=stack.id %}">Detail</a>
                 </li>
                 <li role="presentation"{% if page_id == 'properties' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:stack-properties' pk=stack_id %}">Properties</a>
+                    <a href="{% url 'ui:stack-properties' pk=stack.id %}">Properties</a>
                 </li>
                 <li role="presentation"{% if page_id == 'labels' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:stack-labels' pk=stack_id %}">Labels</a>
+                    <a href="{% url 'ui:stack-labels' pk=stack.id %}">Labels</a>
                 </li>
                 <li role="presentation"{% if page_id == 'hosts' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:stack-hosts' pk=stack_id %}">Hosts</a>
+                    <a href="{% url 'ui:stack-hosts' pk=stack.id %}">Hosts</a>
                 </li>
                 <li role="presentation"{% if page_id == 'volumes' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:stack-volumes' pk=stack_id %}">Volumes</a>
+                    <a href="{% url 'ui:stack-volumes' pk=stack.id %}">Volumes</a>
                 </li>
                 <li role="presentation"{% if page_id == 'commands' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:stack-commands' pk=stack_id %}">Commands</a>
+                    <a href="{% url 'ui:stack-commands' pk=stack.id %}">Commands</a>
                 </li>
                 <li role="presentation"{% if page_id == 'access-rules' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:stack-access-rules' pk=stack_id %}">Access Rules</a>
+                    <a href="{% url 'ui:stack-access-rules' pk=stack.id %}">Access Rules</a>
                 </li>
                 <li role="presentation"{% if page_id == 'formula-versions' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:stack-formula-versions' pk=stack_id %}">Formula Versions</a>
+                    <a href="{% url 'ui:stack-formula-versions' pk=stack.id %}">Formula Versions</a>
                 </li>
                 {% if has_admin %}
                 <li role="presentation"{% if page_id == 'permissions' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:stack-object-permissions' pk=stack_id %}">Permissions</a>
+                    <a href="{% url 'ui:stack-object-permissions' pk=stack.id %}">Permissions</a>
                 </li>
                 {% endif %}
                 <li role="presentation"{% if page_id == 'logs' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:stack-logs' pk=stack_id %}">Logs</a>
+                    <a href="{% url 'ui:stack-logs' pk=stack.id %}">Logs</a>
                 </li>
             </ul>
         </div>

--- a/stackdio/ui/templates/stacks/stack-detail-base.html
+++ b/stackdio/ui/templates/stacks/stack-detail-base.html
@@ -12,7 +12,9 @@
         window.stackdio.stackTitle = '{{ stack.title }}';
         window.stackdio.blueprintId = {{ stack.blueprint.id }};
         window.stackdio.blueprintTitle = '{{ stack.blueprint.title }}  --  {{ stack.blueprint.description }}';
+        {% if has_update != None %}
         window.stackdio.hasUpdatePerm = {{ has_update | lower }};
+        {% endif %}
     </script>
 {% endblock %}
 

--- a/stackdio/ui/templates/stacks/stack-detail-base.html
+++ b/stackdio/ui/templates/stacks/stack-detail-base.html
@@ -12,6 +12,7 @@
         window.stackdio.stackTitle = '{{ stack.title }}';
         window.stackdio.blueprintId = {{ stack.blueprint.id }};
         window.stackdio.blueprintTitle = '{{ stack.blueprint.title }}  --  {{ stack.blueprint.description }}';
+        window.stackdio.hasUpdatePerm = {{ has_update | lower }};
     </script>
 {% endblock %}
 
@@ -32,6 +33,7 @@
                 <li role="presentation"{% if page_id == 'hosts' %} class="active"{% endif %}>
                     <a href="{% url 'ui:stack-hosts' pk=stack.id %}">Hosts</a>
                 </li>
+                {% if user.settings.advanced_view %}
                 <li role="presentation"{% if page_id == 'volumes' %} class="active"{% endif %}>
                     <a href="{% url 'ui:stack-volumes' pk=stack.id %}">Volumes</a>
                 </li>
@@ -44,6 +46,7 @@
                 <li role="presentation"{% if page_id == 'formula-versions' %} class="active"{% endif %}>
                     <a href="{% url 'ui:stack-formula-versions' pk=stack.id %}">Formula Versions</a>
                 </li>
+                {% endif %}
                 {% if has_admin %}
                 <li role="presentation"{% if page_id == 'permissions' %} class="active"{% endif %}>
                     <a href="{% url 'ui:stack-object-permissions' pk=stack.id %}">Permissions</a>

--- a/stackdio/ui/templates/stacks/stack-detail.html
+++ b/stackdio/ui/templates/stacks/stack-detail.html
@@ -42,6 +42,7 @@
                     </div>
                 </div>
                 <div class="form-group" style="margin-top: 15px">
+                    {% if has_update %}
                     <button type="submit" class="btn btn-primary">Save</button>
 
                     <div class="btn-group action-dropdown">
@@ -58,11 +59,14 @@
                             </li>
                         </ul>
                     </div>
+                    {% endif %}
 
+                    {% if has_delete %}
                     <button class="btn btn-danger" data-bind="click: function () { stack.delete() }">
                         Delete
                         <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                     </button>
+                    {% endif %}
                 </div>
             </form>
         </div>

--- a/stackdio/ui/templates/stacks/stack-detail.html
+++ b/stackdio/ui/templates/stacks/stack-detail.html
@@ -24,6 +24,10 @@
                     <label>Namespace</label>
                     <p class="form-control-static" data-bind="text: stack.namespace"></p>
                 </div>
+                <div id="status" class="form-group">
+                    <label>Status</label>
+                    <p class="form-control-static"><span class="label" data-bind="css: stack.labelClass, text: stack.status"></span></p>
+                </div>
                 <div id="created" class="form-group">
                     <label>Launched</label>
                     <p class="form-control-static" data-bind="text: stack.created().calendar()"></p>

--- a/stackdio/ui/templates/stacks/stack-formula-versions.html
+++ b/stackdio/ui/templates/stacks/stack-formula-versions.html
@@ -23,9 +23,13 @@
                     <!-- ko foreach: sortedObjects -->
                     <tr class="stackdio-hidden-on-load" data-bind="visible: $root.versionsReady">
                         <td data-bind="text: formula"></td>
+                        {% if has_update %}
                         <td>
                             <select style="width: 100%" class="hidden-formula-versions" data-bind="attr: {id: formulaHtmlId}"></select>
                         </td>
+                        {% else %}
+                        <td data-bind="text: version"></td>
+                        {% endif %}
                     </tr>
                     <!-- /ko -->
                     </tbody>
@@ -33,10 +37,12 @@
             </div>
         </div>
 
+        {% if has_update %}
         <div class="row">
             <div class="col-md-12">
                 <button type="submit" class="btn btn-primary" data-bind="click: function () { saveVersions() }">Save</button>
             </div>
         </div>
+        {% endif %}
     </div>
 {% endblock %}

--- a/stackdio/ui/templates/stacks/stack-formula-versions.html
+++ b/stackdio/ui/templates/stacks/stack-formula-versions.html
@@ -21,7 +21,7 @@
                     </thead>
                     <tbody>
                     <!-- ko foreach: sortedObjects -->
-                    <tr class="stackdio-hidden-on-load">
+                    <tr class="stackdio-hidden-on-load" data-bind="visible: $root.versionsReady">
                         <td data-bind="text: formula"></td>
                         <td>
                             <select style="width: 100%" class="hidden-formula-versions" data-bind="attr: {id: formulaHtmlId}"></select>

--- a/stackdio/ui/templates/stacks/stack-hosts.html
+++ b/stackdio/ui/templates/stacks/stack-hosts.html
@@ -2,6 +2,7 @@
 
 {% block detail-content %}
 <div class="col-sm-9 col-sm-pull-3">
+    {% if has_update %}
     <h4 class="text-center">Add or remove hosts from this stack</h4>
 
     <div class="row">
@@ -36,6 +37,7 @@
             </div>
         </div>
     </div>
+    {% endif %}
 
     {% include 'stackdio/stubs/pager.html' with object_type='hosts' search=True %}
 

--- a/stackdio/ui/templates/stacks/stack-list.html
+++ b/stackdio/ui/templates/stacks/stack-list.html
@@ -52,7 +52,8 @@
                     </td>
                     <td>
                         <div class="btn-group btn-group-xs action-dropdown"
-                             data-bind="css: {open: $root.openActionStackId === id}, attr: {id: id}">
+                             data-bind="css: {open: $root.openActionStackId === id},
+                                        attr: {id: id}, if: $root.permissionsMap[$data.id].update">
                             <button type="button" class="btn btn-xs btn-info dropdown-toggle"
                                     data-toggle="dropdown" aria-haspopup="true"
                                     aria-expanded="false">
@@ -68,7 +69,7 @@
                         </div>
                     </td>
                     <td class="text-center">
-                        <a href="#" data-bind="click: $data.delete">
+                        <a href="#" data-bind="click: $data.delete, if: $root.permissionsMap[$data.id].delete">
                             <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                         </a>
                     </td>

--- a/stackdio/ui/templates/stacks/stack-properties.html
+++ b/stackdio/ui/templates/stacks/stack-properties.html
@@ -10,11 +10,17 @@
                 <div class="form-group" id="properties">
                     <label for="stackProperties">Properties</label>
 
+                    {% if has_update %}
                     <textarea class="form-control" id="stackProperties" rows="25"
                               data-bind="value: propertiesJSON, valueUpdate: 'keyup'"></textarea>
+                    {% else %}
+                    <pre data-bind="text: propertiesJSON"></pre>
+                    {% endif %}
                 </div>
 
+                {% if has_update %}
                 <button type="submit" class="btn btn-success">Save</button>
+                {% endif %}
             </form>
         </div>
     </div>

--- a/stackdio/ui/templates/users/group-detail-base.html
+++ b/stackdio/ui/templates/users/group-detail-base.html
@@ -8,7 +8,7 @@
     {{ block.super }}
     <script type="text/javascript">
         if (typeof window.stackdio == 'undefined') window.stackdio = {};
-        window.stackdio.groupName = '{{ group_name }}';
+        window.stackdio.groupName = '{{ group.name }}';
     </script>
 {% endblock %}
 
@@ -18,14 +18,14 @@
         <div class="col-sm-3 col-sm-push-9">
             <ul class="nav nav-pills nav-stacked">
                 <li role="presentation"{% if page_id == 'detail' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:group-detail' name=group_name %}">Detail</a>
+                    <a href="{% url 'ui:group-detail' name=group.name %}">Detail</a>
                 </li>
                 <li role="presentation"{% if page_id == 'members' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:group-members' name=group_name %}">Members</a>
+                    <a href="{% url 'ui:group-members' name=group.name %}">Members</a>
                 </li>
                 {% if has_admin %}
                 <li role="presentation"{% if page_id == 'permissions' %} class="active"{% endif %}>
-                    <a href="{% url 'ui:group-object-permissions' name=group_name %}">Permissions</a>
+                    <a href="{% url 'ui:group-object-permissions' name=group.name %}">Permissions</a>
                 </li>
                 {% endif %}
             </ul>

--- a/stackdio/ui/templates/users/group-detail.html
+++ b/stackdio/ui/templates/users/group-detail.html
@@ -13,12 +13,16 @@
                 </div>
 
                 <div class="form-group" style="margin-top: 15px">
+                    {% if has_update %}
                     <button type="submit" class="btn btn-primary">Save</button>
+                    {% endif %}
 
+                    {% if has_delete %}
                     <button class="btn btn-danger" data-bind="click: function () { group.delete() }">
                         Delete
                         <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                     </button>
+                    {% endif %}
                 </div>
             </form>
         </div>

--- a/stackdio/ui/templates/users/group-list.html
+++ b/stackdio/ui/templates/users/group-list.html
@@ -42,7 +42,7 @@
                 <tr class="stackdio-hidden-on-load">
                     <td data-bind="text: name, click: function (group) { $root.goToDetailPage(group) }"></td>
                     <td class="text-center">
-                        <a href="#" data-bind="click: $data.delete">
+                        <a href="#" data-bind="click: $data.delete, if: $root.permissionsMap[$data.name()] && $root.permissionsMap[$data.name()].delete">
                             <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                         </a>
                     </td>

--- a/stackdio/ui/utils.py
+++ b/stackdio/ui/utils.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2014,  Digital Reasoning
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from django.db.models import Model
+
+
+def get_object_list(user, model_cls, pk_field='id'):
+    assert issubclass(model_cls, Model)
+
+    model_name = model_cls._meta.model_name
+
+    object_list = []
+    for obj in model_cls.objects.all():
+        if user.has_perm('view_%s' % model_name, obj):
+            object_list.append({
+                'id': getattr(obj, pk_field),
+                'can_delete': user.has_perm('delete_%s' % model_name, obj),
+                'can_update': user.has_perm('update_%s' % model_name, obj),
+            })
+    return object_list

--- a/stackdio/ui/views/accounts.py
+++ b/stackdio/ui/views/accounts.py
@@ -20,6 +20,7 @@ from django.shortcuts import get_object_or_404
 
 from stackdio.api.cloud.models import CloudAccount
 from stackdio.ui.views import PageView, ModelPermissionsView, ObjectPermissionsView
+from stackdio.ui.utils import get_object_list
 
 
 class AccountCreateView(PageView):
@@ -41,6 +42,7 @@ class AccountListView(PageView):
         context = super(AccountListView, self).get_context_data(**kwargs)
         context['has_admin'] = self.request.user.has_perm('cloud.admin_cloudaccount')
         context['has_create'] = self.request.user.has_perm('cloud.create_cloudaccount')
+        context['object_list'] = get_object_list(self.request.user, CloudAccount)
         return context
 
 
@@ -64,6 +66,8 @@ class AccountDetailView(PageView):
             raise Http404()
         context['account_id'] = pk
         context['has_admin'] = self.request.user.has_perm('cloud.admin_cloudaccount', account)
+        context['has_delete'] = self.request.user.has_perm('cloud.delete_cloudaccount', account)
+        context['has_update'] = self.request.user.has_perm('cloud.update_cloudaccount', account)
         context['page_id'] = self.page_id
         return context
 

--- a/stackdio/ui/views/accounts.py
+++ b/stackdio/ui/views/accounts.py
@@ -64,7 +64,7 @@ class AccountDetailView(PageView):
         account = get_object_or_404(CloudAccount.objects.all(), pk=pk)
         if not self.request.user.has_perm('cloud.view_cloudaccount', account):
             raise Http404()
-        context['account_id'] = pk
+        context['account'] = account
         context['has_admin'] = self.request.user.has_perm('cloud.admin_cloudaccount', account)
         context['has_delete'] = self.request.user.has_perm('cloud.delete_cloudaccount', account)
         context['has_update'] = self.request.user.has_perm('cloud.update_cloudaccount', account)
@@ -85,7 +85,7 @@ class AccountObjectPermissionsView(ObjectPermissionsView):
         account = get_object_or_404(CloudAccount.objects.all(), pk=pk)
         if not self.request.user.has_perm('cloud.admin_cloudaccount', account):
             raise Http404()
-        context['account_id'] = pk
+        context['account'] = account
         context['has_admin'] = self.request.user.has_perm('cloud.admin_cloudaccount', account)
         context['page_id'] = self.page_id
         return context

--- a/stackdio/ui/views/blueprints.py
+++ b/stackdio/ui/views/blueprints.py
@@ -53,7 +53,7 @@ class BlueprintDetailView(PageView):
         blueprint = get_object_or_404(Blueprint.objects.all(), pk=pk)
         if not self.request.user.has_perm('blueprints.view_blueprint', blueprint):
             raise Http404()
-        context['blueprint_id'] = pk
+        context['blueprint'] = blueprint
         context['has_admin'] = self.request.user.has_perm('blueprints.admin_blueprint', blueprint)
         context['has_delete'] = self.request.user.has_perm('blueprints.delete_blueprint', blueprint)
         context['has_update'] = self.request.user.has_perm('blueprints.update_blueprint', blueprint)
@@ -74,7 +74,7 @@ class BlueprintObjectPermissionsView(ObjectPermissionsView):
         blueprint = get_object_or_404(Blueprint.objects.all(), pk=pk)
         if not self.request.user.has_perm('blueprints.admin_blueprint', blueprint):
             raise Http404()
-        context['blueprint_id'] = pk
+        context['blueprint'] = blueprint
         context['has_admin'] = self.request.user.has_perm('blueprints.admin_blueprint', blueprint)
         context['page_id'] = self.page_id
         return context

--- a/stackdio/ui/views/blueprints.py
+++ b/stackdio/ui/views/blueprints.py
@@ -20,6 +20,7 @@ from django.shortcuts import get_object_or_404
 
 from stackdio.api.blueprints.models import Blueprint
 from stackdio.ui.views import PageView, ModelPermissionsView, ObjectPermissionsView
+from stackdio.ui.utils import get_object_list
 
 
 class BlueprintListView(PageView):
@@ -30,6 +31,7 @@ class BlueprintListView(PageView):
         context = super(BlueprintListView, self).get_context_data(**kwargs)
         context['has_admin'] = self.request.user.has_perm('blueprints.admin_blueprint')
         context['has_create'] = self.request.user.has_perm('blueprints.create_blueprint')
+        context['object_list'] = get_object_list(self.request.user, Blueprint)
         return context
 
 
@@ -53,6 +55,8 @@ class BlueprintDetailView(PageView):
             raise Http404()
         context['blueprint_id'] = pk
         context['has_admin'] = self.request.user.has_perm('blueprints.admin_blueprint', blueprint)
+        context['has_delete'] = self.request.user.has_perm('blueprints.delete_blueprint', blueprint)
+        context['has_update'] = self.request.user.has_perm('blueprints.update_blueprint', blueprint)
         context['page_id'] = self.page_id
         return context
 

--- a/stackdio/ui/views/formulas.py
+++ b/stackdio/ui/views/formulas.py
@@ -64,7 +64,7 @@ class FormulaDetailView(PageView):
         formula = get_object_or_404(Formula.objects.all(), pk=pk)
         if not self.request.user.has_perm('formulas.view_formula', formula):
             raise Http404()
-        context['formula_id'] = pk
+        context['formula'] = formula
         context['has_admin'] = self.request.user.has_perm('formulas.admin_formula', formula)
         context['has_delete'] = self.request.user.has_perm('formulas.delete_formula', formula)
         context['has_update'] = self.request.user.has_perm('formulas.update_formula', formula)
@@ -85,7 +85,7 @@ class FormulaObjectPermissionsView(ObjectPermissionsView):
         formula = get_object_or_404(Formula.objects.all(), pk=pk)
         if not self.request.user.has_perm('formulas.admin_formula', formula):
             raise Http404()
-        context['formula_id'] = pk
+        context['formula'] = formula
         context['has_admin'] = self.request.user.has_perm('formulas.admin_formula', formula)
         context['page_id'] = self.page_id
         return context

--- a/stackdio/ui/views/formulas.py
+++ b/stackdio/ui/views/formulas.py
@@ -20,6 +20,7 @@ from django.shortcuts import get_object_or_404
 
 from stackdio.api.formulas.models import Formula
 from stackdio.ui.views import PageView, ModelPermissionsView, ObjectPermissionsView
+from stackdio.ui.utils import get_object_list
 
 
 class FormulaImportView(PageView):
@@ -41,6 +42,7 @@ class FormulaListView(PageView):
         context = super(FormulaListView, self).get_context_data(**kwargs)
         context['has_admin'] = self.request.user.has_perm('formulas.admin_formula')
         context['has_create'] = self.request.user.has_perm('formulas.create_formula')
+        context['object_list'] = get_object_list(self.request.user, Formula)
         return context
 
 
@@ -64,6 +66,8 @@ class FormulaDetailView(PageView):
             raise Http404()
         context['formula_id'] = pk
         context['has_admin'] = self.request.user.has_perm('formulas.admin_formula', formula)
+        context['has_delete'] = self.request.user.has_perm('formulas.delete_formula', formula)
+        context['has_update'] = self.request.user.has_perm('formulas.update_formula', formula)
         context['page_id'] = self.page_id
         return context
 

--- a/stackdio/ui/views/images.py
+++ b/stackdio/ui/views/images.py
@@ -64,9 +64,7 @@ class ImageDetailView(PageView):
         image = get_object_or_404(CloudImage.objects.all(), pk=pk)
         if not self.request.user.has_perm('cloud.view_cloudimage', image):
             raise Http404()
-        context['image_id'] = pk
-        context['account_id'] = image.account.id
-        context['provider_name'] = image.account.provider.name
+        context['image'] = image
         context['has_admin'] = self.request.user.has_perm('cloud.admin_cloudimage', image)
         context['has_delete'] = self.request.user.has_perm('cloud.delete_cloudimage', image)
         context['has_update'] = self.request.user.has_perm('cloud.update_cloudimage', image)
@@ -87,7 +85,7 @@ class ImageObjectPermissionsView(ObjectPermissionsView):
         image = get_object_or_404(CloudImage.objects.all(), pk=pk)
         if not self.request.user.has_perm('cloud.admin_cloudimage', image):
             raise Http404()
-        context['image_id'] = pk
+        context['image'] = image
         context['has_admin'] = self.request.user.has_perm('cloud.admin_cloudimage', image)
         context['page_id'] = self.page_id
         return context

--- a/stackdio/ui/views/images.py
+++ b/stackdio/ui/views/images.py
@@ -20,6 +20,7 @@ from django.shortcuts import get_object_or_404
 
 from stackdio.api.cloud.models import CloudImage
 from stackdio.ui.views import PageView, ModelPermissionsView, ObjectPermissionsView
+from stackdio.ui.utils import get_object_list
 
 
 class ImageCreateView(PageView):
@@ -41,6 +42,7 @@ class ImageListView(PageView):
         context = super(ImageListView, self).get_context_data(**kwargs)
         context['has_admin'] = self.request.user.has_perm('cloud.admin_cloudimage')
         context['has_create'] = self.request.user.has_perm('cloud.create_cloudimage')
+        context['object_list'] = get_object_list(self.request.user, CloudImage)
         return context
 
 
@@ -66,6 +68,8 @@ class ImageDetailView(PageView):
         context['account_id'] = image.account.id
         context['provider_name'] = image.account.provider.name
         context['has_admin'] = self.request.user.has_perm('cloud.admin_cloudimage', image)
+        context['has_delete'] = self.request.user.has_perm('cloud.delete_cloudimage', image)
+        context['has_update'] = self.request.user.has_perm('cloud.update_cloudimage', image)
         context['page_id'] = self.page_id
         return context
 

--- a/stackdio/ui/views/snapshots.py
+++ b/stackdio/ui/views/snapshots.py
@@ -20,6 +20,7 @@ from django.shortcuts import get_object_or_404
 
 from stackdio.api.cloud.models import Snapshot
 from stackdio.ui.views import PageView, ModelPermissionsView, ObjectPermissionsView
+from stackdio.ui.utils import get_object_list
 
 
 class SnapshotCreateView(PageView):
@@ -41,6 +42,7 @@ class SnapshotListView(PageView):
         context = super(SnapshotListView, self).get_context_data(**kwargs)
         context['has_admin'] = self.request.user.has_perm('cloud.admin_snapshot')
         context['has_create'] = self.request.user.has_perm('cloud.create_snapshot')
+        context['object_list'] = get_object_list(self.request.user, Snapshot)
         return context
 
 
@@ -64,6 +66,8 @@ class SnapshotDetailView(PageView):
             raise Http404()
         context['snapshot_id'] = pk
         context['has_admin'] = self.request.user.has_perm('cloud.admin_snapshot', snapshot)
+        context['has_delete'] = self.request.user.has_perm('cloud.delete_snapshot', snapshot)
+        context['has_update'] = self.request.user.has_perm('cloud.update_snapshot', snapshot)
         context['page_id'] = self.page_id
         return context
 

--- a/stackdio/ui/views/snapshots.py
+++ b/stackdio/ui/views/snapshots.py
@@ -64,7 +64,7 @@ class SnapshotDetailView(PageView):
         snapshot = get_object_or_404(Snapshot.objects.all(), pk=pk)
         if not self.request.user.has_perm('cloud.view_snapshot', snapshot):
             raise Http404()
-        context['snapshot_id'] = pk
+        context['snapshot'] = snapshot
         context['has_admin'] = self.request.user.has_perm('cloud.admin_snapshot', snapshot)
         context['has_delete'] = self.request.user.has_perm('cloud.delete_snapshot', snapshot)
         context['has_update'] = self.request.user.has_perm('cloud.update_snapshot', snapshot)
@@ -85,7 +85,7 @@ class SnapshotObjectPermissionsView(ObjectPermissionsView):
         snapshot = get_object_or_404(Snapshot.objects.all(), pk=pk)
         if not self.request.user.has_perm('cloud.admin_snapshot', snapshot):
             raise Http404()
-        context['snapshot_id'] = pk
+        context['snapshot'] = snapshot
         context['has_admin'] = self.request.user.has_perm('cloud.admin_snapshot', snapshot)
         context['page_id'] = self.page_id
         return context

--- a/stackdio/ui/views/stacks.py
+++ b/stackdio/ui/views/stacks.py
@@ -63,7 +63,7 @@ class StackDetailView(PageView):
         stack = get_object_or_404(Stack.objects.all(), pk=pk)
         if not self.request.user.has_perm('stacks.view_stack', stack):
             raise Http404()
-        context['stack_id'] = pk
+        context['stack'] = stack
         context['has_admin'] = self.request.user.has_perm('stacks.admin_stack', stack)
         context['has_delete'] = self.request.user.has_perm('stacks.delete_stack', stack)
         context['has_update'] = self.request.user.has_perm('stacks.update_stack', stack)
@@ -83,7 +83,7 @@ class StackObjectPermissionsView(ObjectPermissionsView):
         stack = get_object_or_404(Stack.objects.all(), pk=pk)
         if not self.request.user.has_perm('stacks.admin_stack', stack):
             raise Http404()
-        context['stack_id'] = pk
+        context['stack'] = stack
         context['has_admin'] = self.request.user.has_perm('stacks.admin_stack', stack)
         context['page_id'] = self.page_id
         return context

--- a/stackdio/ui/views/stacks.py
+++ b/stackdio/ui/views/stacks.py
@@ -20,6 +20,7 @@ from django.shortcuts import get_object_or_404
 
 from stackdio.api.stacks.models import Stack, StackCommand
 from stackdio.ui.views import PageView, ModelPermissionsView, ObjectPermissionsView
+from stackdio.ui.utils import get_object_list
 
 
 class StackCreateView(PageView):
@@ -41,6 +42,7 @@ class StackListView(PageView):
         context = super(StackListView, self).get_context_data(**kwargs)
         context['has_admin'] = self.request.user.has_perm('stacks.admin_stack')
         context['has_create'] = self.request.user.has_perm('stacks.create_stack')
+        context['object_list'] = get_object_list(self.request.user, Stack)
         return context
 
 
@@ -63,6 +65,8 @@ class StackDetailView(PageView):
             raise Http404()
         context['stack_id'] = pk
         context['has_admin'] = self.request.user.has_perm('stacks.admin_stack', stack)
+        context['has_delete'] = self.request.user.has_perm('stacks.delete_stack', stack)
+        context['has_update'] = self.request.user.has_perm('stacks.update_stack', stack)
         context['page_id'] = self.page_id
         return context
 

--- a/stackdio/ui/views/users.py
+++ b/stackdio/ui/views/users.py
@@ -116,7 +116,7 @@ class GroupDetailView(PageView):
         group = get_object_or_404(Group.objects.all(), name=name)
         if not self.request.user.has_perm('auth.view_group', group):
             raise Http404()
-        context['group_name'] = name
+        context['group'] = group
         context['has_admin'] = self.request.user.has_perm('auth.admin_group', group)
         context['has_delete'] = self.request.user.has_perm('auth.delete_group', group)
         context['has_update'] = self.request.user.has_perm('auth.update_group', group)
@@ -136,7 +136,7 @@ class GroupObjectPermissionsView(ObjectPermissionsView):
         group = get_object_or_404(Group.objects.all(), name=name)
         if not self.request.user.has_perm('auth.admin_group', group):
             raise Http404()
-        context['group_name'] = name
+        context['group'] = group
         context['object_id'] = name
         context['has_admin'] = self.request.user.has_perm('auth.admin_group', group)
         context['page_id'] = self.page_id

--- a/stackdio/ui/views/users.py
+++ b/stackdio/ui/views/users.py
@@ -22,6 +22,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 
 from stackdio.ui.views import PageView, ModelPermissionsView, ObjectPermissionsView
+from stackdio.ui.utils import get_object_list
 
 
 class FailOnLDAPMixin(object):
@@ -94,6 +95,7 @@ class GroupListView(PageView):
         context = super(GroupListView, self).get_context_data(**kwargs)
         context['has_admin'] = self.request.user.has_perm('auth.admin_group')
         context['has_create'] = self.request.user.has_perm('auth.create_group')
+        context['object_list'] = get_object_list(self.request.user, Group, 'name')
         return context
 
 
@@ -116,6 +118,8 @@ class GroupDetailView(PageView):
             raise Http404()
         context['group_name'] = name
         context['has_admin'] = self.request.user.has_perm('auth.admin_group', group)
+        context['has_delete'] = self.request.user.has_perm('auth.delete_group', group)
+        context['has_update'] = self.request.user.has_perm('auth.update_group', group)
         context['page_id'] = self.page_id
         return context
 


### PR DESCRIPTION
Includes fixes for:
* PI-504
* PI-506

These bugs aren't captured in a ticket:
* When deleting objects in the UI, you now get redirected back to the list page
* Many pieces of the UI have been hidden if users don't have permission to use them (PI-504)
* Requests to endpoints that begin with `/api/` have the ability to return JSON 404 responses instead of HTML (PI-506)
* Fixed an issue with error messages in the UI when deleting formulas / blueprints
* (Kind of) fixed an issue where we would get a msgpack exception with launching / terminating stacks
* Added a `q=` url parameter to most major list endpoints that will try to match text in all fields instead of a single field
* If a user becomes logged out while a page is autorefeshing, the page now redirects back to the login page instead of overloading the server with requests
* Stack creation page now has dropdowns for formula versions too
* During orchestration when pillar files are generated, the formulas are updated too