### PR TITLE
add setuptools to required pkg versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ requirements = [
     'PyYAML>=3.10',
     'requests>=2.4',
     'six>=1.6',
+    'setuptools>=40.0',
 ]
 
 testing_requirements = [


### PR DESCRIPTION
Salt would not start after an upgrade. Error message of

` ValueError: ('Expected version spec in', 'celery[redis] ~=3.1.0', 'at', ' ~=3.1.0')`

fix turned out to be `pip install -U setuptools`

Not positive how to test this but it seems sane.